### PR TITLE
feat(profile): JSP view + servlet forwarding; seed ids 1..2; singleton service

### DIFF
--- a/resources/WEB-INF/jsp/footer.html
+++ b/resources/WEB-INF/jsp/footer.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html lang="en">
+    <div>
+        <hr>
+        <h3>All rights reserved 2025</h3>
+    </div>
+</html>

--- a/resources/WEB-INF/jsp/header.html
+++ b/resources/WEB-INF/jsp/header.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html lang="en">
+    <div>
+        <h3>Charm <3</h3>
+        <hr>
+    </div>
+</html>

--- a/resources/WEB-INF/jsp/profile.jsp
+++ b/resources/WEB-INF/jsp/profile.jsp
@@ -1,0 +1,30 @@
+<%@ page contentType="text/html;charset=UTF-8" %>
+<html lang="en">
+    <head>
+      <title>Charm Profile</title>
+    </head>
+    <body>
+    <%@ include file="header.html" %>
+        <div>
+           <table>
+               <tr>
+                   <td><h3>Email</h3></td>
+                   <td>${requestScope.profile.email}</td>
+               </tr>
+               <tr>
+                   <td><h3>Name</h3></td>
+                   <td>${requestScope.profile.name}</td>
+               </tr>
+               <tr>
+                   <td><h3>Surname</h3></td>
+                   <td>${requestScope.profile.surname}</td>
+               </tr>
+               <tr>
+                   <td><h3>About</h3></td>
+                   <td>${requestScope.profile.about}</td>
+               </tr>
+           </table>
+        </div>
+        <%@ include file="footer.html" %>
+    </body>
+</html>

--- a/src/ru/andrewb/charm/back/controller/ProfileController.java
+++ b/src/ru/andrewb/charm/back/controller/ProfileController.java
@@ -1,90 +1,44 @@
 package ru.andrewb.charm.back.controller;
 
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import ru.andrewb.charm.back.model.Profile;
 import ru.andrewb.charm.back.service.ProfileService;
 
+import java.io.IOException;
 import java.util.Optional;
 
-public class ProfileController {
+@WebServlet("/profile")
+public class ProfileController extends HttpServlet {
 
-    private final ProfileService service;
+    private final ProfileService service = ProfileService.getInstance();
 
-    public ProfileController(ProfileService service) {
-        this.service = service;
-    }
-
-    public String save(String request) {
-        String[] strings = request.split(",");
-        if (strings.length != 4) return "Bad request: need 4 parameters to save profile.";
-
-        Profile profile = new Profile();
-        profile.setEmail(strings[0]);
-        profile.setName(strings[1]);
-        profile.setSurname(strings[2]);
-        profile.setAbout(strings[3]);
-
-        return service.save(profile).toString();
-    }
-
-    public String findById(String request) {
-        String[] strings = request.split(",");
-        if (strings.length != 1) return "Bad request: need one number parameter.";
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        String idParam = req.getParameter("id");
+        if (idParam == null) {
+            resp.sendError(HttpServletResponse.SC_BAD_REQUEST, "Query param: 'id' is required");
+            return;
+        }
 
         long id;
         try {
-            id = Long.parseLong(strings[0]);
-        } catch (NumberFormatException e) {
-            return "Bad request: can`t parse string [" + strings[0] + "] to long.";
+            id = Long.parseLong(idParam);
+            if (id <= 0) throw new NumberFormatException("negative");
+        } catch (Exception e) {
+            resp.sendError(HttpServletResponse.SC_BAD_REQUEST, "Param 'id' must be positive long");
+            return;
         }
 
-        Optional<Profile> foundProfile = service.findById(id);
-        if (foundProfile.isEmpty()) return "Not found";
-
-        return foundProfile.get().toString();
-    }
-
-    public String findAll() {
-        return service.findAll().toString();
-    }
-
-    public String update(String request) {
-        String[] strings = request.split(",");
-        if (strings.length != 5) return "Bad request: need 5 parameters to update profile.";
-
-        long id;
-        try {
-            id = Long.parseLong(strings[0]);
-        } catch (NumberFormatException e) {
-            return "Bad request: can`t parse string [" + strings[0] + "] to long.";
+        Optional<Profile> profileOptional = service.findById(id);
+        if (profileOptional.isEmpty()) {
+            resp.sendError(HttpServletResponse.SC_NOT_FOUND, "Profile not found");
+            return;
         }
-
-        Profile profile = new Profile();
-        profile.setId(id);
-        profile.setEmail(strings[1]);
-        profile.setName(strings[2]);
-        profile.setSurname(strings[3]);
-        profile.setAbout(strings[4]);
-
-        service.update(profile);
-
-        return "Update success.";
-    }
-
-    public String delete(String request) {
-        String[] strings = request.split(",");
-        if (strings.length != 1) return "Bad request: need 1 number parameter.";
-
-        long id;
-        try {
-            id = Long.parseLong(strings[0]);
-        } catch (NumberFormatException e) {
-            return "Bad request: can`t parse string [" + strings[0] + "] to long.";
-        }
-
-        boolean result = service.delete(id);
-
-        if (!result) return "Not found.";
-
-        return "Delete success.";
+        req.setAttribute("profile", profileOptional.get());
+        req.getRequestDispatcher("/WEB-INF/jsp/profile.jsp").forward(req, resp);
     }
 }

--- a/src/ru/andrewb/charm/back/dao/ProfileDao.java
+++ b/src/ru/andrewb/charm/back/dao/ProfileDao.java
@@ -10,12 +10,35 @@ import java.util.concurrent.atomic.AtomicLong;
 
 public class ProfileDao {
 
+    private static final ProfileDao INSTANCE = new ProfileDao();
+
     private final ConcurrentHashMap<Long, Profile> storage;
     private final AtomicLong idStorage;
 
-    public ProfileDao() {
+    private ProfileDao() {
         this.storage = new ConcurrentHashMap<>();
-        this.idStorage = new AtomicLong();
+
+        Profile profile1 = new Profile();
+        profile1.setId(1L);
+        profile1.setEmail("ivanov@mail.ru");
+        profile1.setName("Ivan");
+        profile1.setSurname("Ivanov");
+        profile1.setAbout("I am QA");
+        this.storage.put(1L, profile1);
+
+        Profile profile2 = new Profile();
+        profile2.setId(2L);
+        profile2.setEmail("sidorova@mail.ru");
+        profile2.setName("Elena");
+        profile2.setSurname("Sidorova");
+        profile2.setAbout("I am Java Dev");
+        this.storage.put(2L, profile2);
+
+        this.idStorage = new AtomicLong(3L);
+    }
+
+    public static ProfileDao getInstance() {
+        return INSTANCE;
     }
 
     public Profile save(Profile profile) {

--- a/src/ru/andrewb/charm/back/service/ProfileService.java
+++ b/src/ru/andrewb/charm/back/service/ProfileService.java
@@ -8,10 +8,15 @@ import java.util.Optional;
 
 public class ProfileService {
 
-    private final ProfileDao dao;
+    private static final ProfileService INSTANCE = new ProfileService();
 
-    public ProfileService(ProfileDao dao) {
-        this.dao = dao;
+    private final ProfileDao dao = ProfileDao.getInstance();
+
+    private ProfileService() {
+    }
+
+    public static ProfileService getInstance() {
+        return INSTANCE;
     }
 
     public Profile save(Profile profile) {


### PR DESCRIPTION
### Summary
- Implement GET `/profile?id=…` in `ProfileController`:
  - validates `id` (400 on missing/invalid/non-positive)
  - 404 when profile not found
  - forwards to JSP on success
- Add JSP views under `/WEB-INF/jsp`:
  - `profile.jsp` + header/footer fragments (`*.jspf`)
- Seed demo data in `ProfileDao` (ids 1 and 2) and start ID counter at 3
- Make `ProfileService` a singleton (`getInstance()`), stateless

### What changed
- `ProfileController#doGet`: `sendError(400/404)` + `forward("/WEB-INF/jsp/profile.jsp")`
- JSP templates: basic layout via `<%@ include %>` fragments
- `ProfileDao`: fixed initial ids; `new AtomicLong(3L)`
- `ProfileService`: singleton pattern (thread-safe, stateless)