### PR TITLE
feat(profile): RESTful forms (PUT/DELETE via filter), unified id validation, JSP form cleanup

### DIFF
--- a/resources/WEB-INF/jsp/footer.html
+++ b/resources/WEB-INF/jsp/footer.html
@@ -1,7 +1,4 @@
-<!DOCTYPE html>
-<html lang="en">
-    <div>
-        <hr>
-        <h3>All rights reserved 2025</h3>
-    </div>
-</html>
+<div>
+    <hr>
+    <h3>All rights reserved 2025</h3>
+</div>

--- a/resources/WEB-INF/jsp/header.html
+++ b/resources/WEB-INF/jsp/header.html
@@ -1,7 +1,4 @@
-<!DOCTYPE html>
-<html lang="en">
-    <div>
-        <h3>Charm <3</h3>
-        <hr>
-    </div>
-</html>
+<div>
+    <h3>Charm <3</h3>
+    <hr>
+</div>

--- a/resources/WEB-INF/jsp/profile.jsp
+++ b/resources/WEB-INF/jsp/profile.jsp
@@ -8,8 +8,8 @@
     <%@ include file="header.html" %>
         <div>
             <form method="post" action="${pageContext.request.contextPath}/profile">
-                <c:if test="${empty requestScope.profile.id}">
-                    <h1>Hello new user!</h1>
+                <c:if test="${!empty requestScope.profile.id}">
+                    <input type="hidden" name="_method" value="PUT">
                 </c:if>
                 <input type="hidden" name="id" value="${requestScope.profile.id}">
                 <table>
@@ -44,6 +44,14 @@
                 </table>
                 <button type="submit">Save</button>
             </form>
+            <c:if test="${!empty requestScope.profile.id}">
+                <form method="post" action="${pageContext.request.contextPath}/profile">
+                    <input type="hidden" name="_method" value="DELETE">
+                    <input type="hidden" name="id" value="${requestScope.profile.id}">
+                    <button type="submit">Delete</button>
+                </form>
+            </c:if>
+
         </div>
         <%@ include file="footer.html" %>
     </body>

--- a/src/ru/andrewb/charm/back/controller/ProfileController.java
+++ b/src/ru/andrewb/charm/back/controller/ProfileController.java
@@ -12,6 +12,8 @@ import ru.andrewb.charm.back.model.Profile;
 import ru.andrewb.charm.back.service.ProfileService;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.Locale;
 import java.util.Optional;
 
 @WebServlet(value = "/profile", loadOnStartup = 1)
@@ -29,20 +31,8 @@ public class ProfileController extends HttpServlet {
 
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
-        String idParam = req.getParameter("id");
-        if (idParam == null) {
-            resp.sendError(HttpServletResponse.SC_BAD_REQUEST, "Query param: 'id' is required");
-            return;
-        }
-
-        long id;
-        try {
-            id = Long.parseLong(idParam);
-            if (id <= 0) throw new NumberFormatException("non-positive");
-        } catch (Exception e) {
-            resp.sendError(HttpServletResponse.SC_BAD_REQUEST, "Param 'id' must be positive long");
-            return;
-        }
+        Long id = requirePositiveLong(req, resp);
+        if (id == null) return;
 
         Optional<Profile> profileOptional = service.findById(id);
         if (profileOptional.isEmpty()) {
@@ -55,33 +45,80 @@ public class ProfileController extends HttpServlet {
 
     @Override
     protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
-        String idParam = req.getParameter("id");
+        Profile profile = createProfile(req, resp);
+        if (profile == null) return;
 
+        long id = service.save(profile).getId();
+        resp.sendRedirect(req.getContextPath() + "/profile?id=" + id);
+    }
+
+    @Override
+    protected void doPut(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        Long id = requirePositiveLong(req, resp);
+        if (id == null) return;
+
+        if (service.findById(id).isEmpty()) {
+            resp.sendError(HttpServletResponse.SC_NOT_FOUND, "Profile not found");
+            return;
+        }
+
+        Profile profile = createProfile(req, resp);
+        if (profile == null) return;
+        profile.setId(id);
+
+        service.update(profile);
+        resp.sendRedirect(req.getContextPath() + "/profile?id=" + id);
+    }
+
+    @Override
+    protected void doDelete(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        Long id = requirePositiveLong(req, resp);
+        if (id ==null) return;
+
+        boolean removed = service.delete(id);
+        if (!removed) {
+            resp.sendError(HttpServletResponse.SC_NOT_FOUND, "Profile not found");
+            return;
+        }
+        resp.sendRedirect(req.getContextPath() + "/registration");
+    }
+
+    private Long requirePositiveLong(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+        String idParam = req.getParameter("id");
+        if (idParam == null || idParam.isBlank()) {
+            resp.sendError(HttpServletResponse.SC_BAD_REQUEST, "Param 'id' is required");
+            return null;
+        }
+        long id;
+        try {
+            id = Long.parseLong(idParam);
+            if (id <= 0) throw new NumberFormatException("non-positive");
+            return id;
+        } catch (NumberFormatException e) {
+            resp.sendError(HttpServletResponse.SC_BAD_REQUEST, "Param 'id' must be positive long");
+            return null;
+        }
+    }
+
+    private Profile createProfile(HttpServletRequest req, HttpServletResponse resp) throws IOException {
         Profile profile = new Profile();
         profile.setEmail(req.getParameter("email"));
         profile.setName(req.getParameter("name"));
         profile.setSurname(req.getParameter("surname"));
         profile.setAbout(req.getParameter("about"));
-        profile.setGender(Gender.valueOf(req.getParameter("gender")));
 
-        Long id = null;
-        if (idParam != null && !idParam.isBlank()) {
-            try {
-                id = Long.parseLong(idParam);
-                if (id <= 0) throw new NumberFormatException("non-positive");
-            } catch (NumberFormatException e) {
-                resp.sendError(HttpServletResponse.SC_BAD_REQUEST, "Param 'id' must be positive long");
-                return;
-            }
+        String gp = req.getParameter("gender");
+        if (gp == null || gp.isBlank()) {
+            resp.sendError(HttpServletResponse.SC_BAD_REQUEST, "Param `gender` is required");
+            return null;
         }
-
-        if (id == null) {
-            id = service.save(profile).getId();
-        } else {
-            profile.setId(id);
-            service.update(profile);
+        try {
+            profile.setGender(Gender.valueOf(gp.toUpperCase(Locale.ROOT)));
+        } catch (IllegalArgumentException e) {
+            resp.sendError(HttpServletResponse.SC_BAD_REQUEST,
+                    "Param `gender` must be one of " + Arrays.toString(Gender.values()));
+            return null;
         }
-
-        resp.sendRedirect(req.getContextPath() + "/profile?id=" + id);
+        return profile;
     }
 }

--- a/src/ru/andrewb/charm/back/controller/filter/HiddenHttpMethodFilter.java
+++ b/src/ru/andrewb/charm/back/controller/filter/HiddenHttpMethodFilter.java
@@ -1,0 +1,49 @@
+package ru.andrewb.charm.back.controller.filter;
+
+import jakarta.servlet.*;
+import jakarta.servlet.annotation.WebFilter;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequestWrapper;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+import java.util.Locale;
+
+@WebFilter("/*")
+public class HiddenHttpMethodFilter implements Filter {
+
+    public static final String METHOD_PARAM = "_method";
+
+    @Override
+    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain) throws IOException, ServletException {
+        HttpServletRequest request = (HttpServletRequest) servletRequest;
+        HttpServletResponse response = (HttpServletResponse) servletResponse;
+
+        String paramValue = request.getParameter(METHOD_PARAM);
+
+        if ("POST".equals(request.getMethod()) && paramValue != null && !paramValue.isBlank()) {
+            String method = paramValue.toUpperCase(Locale.ENGLISH);
+            HttpServletRequest wrapper = new HttpMethodRequestWrapper(request, method);
+            filterChain.doFilter(wrapper, response);
+        } else {
+            filterChain.doFilter(request, response);
+        }
+    }
+
+    private static class HttpMethodRequestWrapper extends HttpServletRequestWrapper {
+
+        private final String method;
+
+        public HttpMethodRequestWrapper(HttpServletRequest request, String method) {
+            super(request);
+            this.method = method;
+        }
+
+        @Override
+        public String getMethod() {
+            return this.method;
+        }
+    }
+
+
+}


### PR DESCRIPTION
### Summary
- Web: HiddenHttpMethodFilter (@WebFilter) to support `_method=PUT|DELETE`.
- Controller:
  - Extract `requirePositiveLong(...)` and use it in GET/PUT/DELETE (400 on missing/blank/non-positive).
  - Extract `createProfile(...)`; add server-side validation for `gender` (case-insensitive, 400 on invalid).
  - POST = create, PUT = update, DELETE = remove; consistent redirects via contextPath.
- JSP:
  - `WEB-INF/jsp/profile.jsp`: method override only for edit, gender <select> with placeholder, action via `${pageContext.request.contextPath}`.
  - `header.html`/`footer.html`: stripped `<html>/<body>` to avoid nested markup.