### PR TITLE
refactor(profile): controller maps HTTP→SaveDto; service maps SaveDto→entity

### DIFF
--- a/src/ru/andrewb/charm/back/controller/ProfileController.java
+++ b/src/ru/andrewb/charm/back/controller/ProfileController.java
@@ -8,21 +8,18 @@ import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import ru.andrewb.charm.back.dto.ProfileGetDto;
+import ru.andrewb.charm.back.mapper.ProfileSaveRequestMapper;
 import ru.andrewb.charm.back.model.Gender;
-import ru.andrewb.charm.back.model.Profile;
 import ru.andrewb.charm.back.service.ProfileService;
 
 import java.io.IOException;
-import java.time.LocalDate;
-import java.time.format.DateTimeParseException;
-import java.util.Arrays;
-import java.util.Locale;
 import java.util.Optional;
 
 @WebServlet(value = "/profile", loadOnStartup = 1)
 public class ProfileController extends HttpServlet {
 
     private final ProfileService service = ProfileService.getInstance();
+    private final ProfileSaveRequestMapper saveRequestMapper = ProfileSaveRequestMapper.getInstance();
 
     @Override
     public void init(ServletConfig config) throws ServletException {
@@ -56,10 +53,9 @@ public class ProfileController extends HttpServlet {
 
     @Override
     protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
-        Profile profile = createProfile(req, resp);
-        if (profile == null) return;
-
-        long id = service.save(profile);
+        var dto = saveRequestMapper.map(req, resp);
+        if (dto == null) return;
+        long id = service.save(dto);
         resp.sendRedirect(req.getContextPath() + "/profile?id=" + id);
     }
 
@@ -67,17 +63,13 @@ public class ProfileController extends HttpServlet {
     protected void doPut(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
         Long id = requirePositiveLong(req, resp);
         if (id == null) return;
-
         if (service.findById(id).isEmpty()) {
             resp.sendError(HttpServletResponse.SC_NOT_FOUND, "Profile not found");
             return;
         }
-
-        Profile profile = createProfile(req, resp);
-        if (profile == null) return;
-        profile.setId(id);
-
-        service.update(profile);
+        var dto = saveRequestMapper.map(req, resp);
+        if (dto == null) return;
+        service.update(id, dto);
         resp.sendRedirect(req.getContextPath() + "/profile?id=" + id);
     }
 
@@ -109,40 +101,5 @@ public class ProfileController extends HttpServlet {
             resp.sendError(HttpServletResponse.SC_BAD_REQUEST, "Param 'id' must be positive long");
             return null;
         }
-    }
-
-    private Profile createProfile(HttpServletRequest req, HttpServletResponse resp) throws IOException {
-        Profile profile = new Profile();
-        profile.setEmail(req.getParameter("email"));
-        profile.setName(req.getParameter("name"));
-        profile.setSurname(req.getParameter("surname"));
-
-        String bd = req.getParameter("birthDate");
-        if (bd == null || bd.isBlank()) {
-            resp.sendError(HttpServletResponse.SC_BAD_REQUEST, "Param `birthDate` is required");
-            return null;
-        }
-        try {
-            profile.setBirthDate(LocalDate.parse(bd));
-        } catch (DateTimeParseException e) {
-            resp.sendError(HttpServletResponse.SC_BAD_REQUEST, "Param `birthDate` must be yyyy-MM-dd");
-            return null;
-        }
-
-        profile.setAbout(req.getParameter("about"));
-
-        String gp = req.getParameter("gender");
-        if (gp == null || gp.isBlank()) {
-            resp.sendError(HttpServletResponse.SC_BAD_REQUEST, "Param `gender` is required");
-            return null;
-        }
-        try {
-            profile.setGender(Gender.valueOf(gp.toUpperCase(Locale.ROOT)));
-        } catch (IllegalArgumentException e) {
-            resp.sendError(HttpServletResponse.SC_BAD_REQUEST,
-                    "Param `gender` must be one of " + Arrays.toString(Gender.values()));
-            return null;
-        }
-        return profile;
     }
 }

--- a/src/ru/andrewb/charm/back/dto/ProfileSaveDto.java
+++ b/src/ru/andrewb/charm/back/dto/ProfileSaveDto.java
@@ -1,0 +1,71 @@
+package ru.andrewb.charm.back.dto;
+
+import ru.andrewb.charm.back.model.Gender;
+
+import java.time.LocalDate;
+
+public class ProfileSaveDto {
+    private Long id;
+    private String email;
+    private String name;
+    private String surname;
+    private String about;
+    private LocalDate birthDate;
+    private Gender gender;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getSurname() {
+        return surname;
+    }
+
+    public void setSurname(String surname) {
+        this.surname = surname;
+    }
+
+    public String getAbout() {
+        return about;
+    }
+
+    public void setAbout(String about) {
+        this.about = about;
+    }
+
+    public LocalDate getBirthDate() {
+        return birthDate;
+    }
+
+    public void setBirthDate(LocalDate birthDate) {
+        this.birthDate = birthDate;
+    }
+
+    public Gender getGender() {
+        return gender;
+    }
+
+    public void setGender(Gender gender) {
+        this.gender = gender;
+    }
+}

--- a/src/ru/andrewb/charm/back/mapper/ProfileMapper.java
+++ b/src/ru/andrewb/charm/back/mapper/ProfileMapper.java
@@ -1,0 +1,29 @@
+package ru.andrewb.charm.back.mapper;
+
+import ru.andrewb.charm.back.dto.ProfileSaveDto;
+import ru.andrewb.charm.back.model.Profile;
+
+public class ProfileMapper implements Mapper<ProfileSaveDto, Profile> {
+
+    private static final ProfileMapper INSTANCE = new ProfileMapper();
+
+    private ProfileMapper() {}
+
+    public static ProfileMapper getInstance() {
+        return INSTANCE;
+    }
+
+    @Override
+    public Profile map(ProfileSaveDto dto) {
+        Profile profile = new Profile();
+        profile.setId(dto.getId());
+        profile.setEmail(dto.getEmail());
+        profile.setName(dto.getName());
+        profile.setSurname(dto.getSurname());
+        profile.setAbout(dto.getAbout());
+        profile.setBirthDate(dto.getBirthDate());
+        profile.setGender(dto.getGender());
+
+        return profile;
+    }
+}

--- a/src/ru/andrewb/charm/back/mapper/ProfileMapper.java
+++ b/src/ru/andrewb/charm/back/mapper/ProfileMapper.java
@@ -16,7 +16,6 @@ public class ProfileMapper implements Mapper<ProfileSaveDto, Profile> {
     @Override
     public Profile map(ProfileSaveDto dto) {
         Profile profile = new Profile();
-        profile.setId(dto.getId());
         profile.setEmail(dto.getEmail());
         profile.setName(dto.getName());
         profile.setSurname(dto.getSurname());

--- a/src/ru/andrewb/charm/back/mapper/ProfileSaveRequestMapper.java
+++ b/src/ru/andrewb/charm/back/mapper/ProfileSaveRequestMapper.java
@@ -1,0 +1,58 @@
+package ru.andrewb.charm.back.mapper;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import ru.andrewb.charm.back.dto.ProfileSaveDto;
+import ru.andrewb.charm.back.model.Gender;
+
+import java.io.IOException;
+import java.time.LocalDate;
+import java.time.format.DateTimeParseException;
+import java.util.Arrays;
+import java.util.Locale;
+
+public class ProfileSaveRequestMapper {
+
+    private static final ProfileSaveRequestMapper INSTANCE = new ProfileSaveRequestMapper();
+
+    private ProfileSaveRequestMapper() {};
+
+    public static ProfileSaveRequestMapper getInstance() {
+        return INSTANCE;
+    }
+
+    public ProfileSaveDto map(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+        ProfileSaveDto dto = new ProfileSaveDto();
+        dto.setEmail(req.getParameter("email"));
+        dto.setName(req.getParameter("name"));
+        dto.setSurname(req.getParameter("surname"));
+        dto.setAbout(req.getParameter("about"));
+
+        String bd = req.getParameter("birthDate");
+        if (bd == null || bd.isBlank()) {
+            resp.sendError(HttpServletResponse.SC_BAD_REQUEST, "Param `birthDate` is required");
+            return null;
+        }
+        try {
+            dto.setBirthDate(LocalDate.parse(bd));
+        } catch (DateTimeParseException e) {
+            resp.sendError(HttpServletResponse.SC_BAD_REQUEST, "Param `birthDate` must be yyyy-MM-dd");
+            return null;
+        }
+
+        String gp = req.getParameter("gender");
+        if (gp == null || gp.isBlank()) {
+            resp.sendError(HttpServletResponse.SC_BAD_REQUEST, "Param `gender` is required");
+            return null;
+        }
+        try {
+            dto.setGender(Gender.valueOf(gp.toUpperCase(Locale.ROOT)));
+        } catch (IllegalArgumentException e) {
+            resp.sendError(HttpServletResponse.SC_BAD_REQUEST,
+                    "Param `gender` must be one of " + Arrays.toString(Gender.values()));
+            return null;
+        }
+
+        return dto;
+    }
+}

--- a/src/ru/andrewb/charm/back/service/ProfileService.java
+++ b/src/ru/andrewb/charm/back/service/ProfileService.java
@@ -2,7 +2,9 @@ package ru.andrewb.charm.back.service;
 
 import ru.andrewb.charm.back.dao.ProfileDao;
 import ru.andrewb.charm.back.dto.ProfileGetDto;
+import ru.andrewb.charm.back.dto.ProfileSaveDto;
 import ru.andrewb.charm.back.mapper.ProfileGetDtoMapper;
+import ru.andrewb.charm.back.mapper.ProfileMapper;
 import ru.andrewb.charm.back.model.Profile;
 
 import java.util.List;
@@ -15,6 +17,7 @@ public class ProfileService {
     private final ProfileDao dao = ProfileDao.getInstance();
 
     private final ProfileGetDtoMapper profileGetDtoMapper = ProfileGetDtoMapper.getInstance();
+    private final ProfileMapper profileMapper = ProfileMapper.getInstance();
 
     private ProfileService() {
     }
@@ -23,7 +26,8 @@ public class ProfileService {
         return INSTANCE;
     }
 
-    public Long save(Profile profile) {
+    public Long save(ProfileSaveDto dto) {
+        Profile profile = profileMapper.map(dto);
         return dao.save(profile).getId();
     }
 
@@ -36,7 +40,9 @@ public class ProfileService {
         return dao.findAll().stream().map(profileGetDtoMapper::map).toList();
     }
 
-    public void update(Profile profile) {
+    public void update(Long id, ProfileSaveDto dto) {
+        Profile profile = profileMapper.map(dto);
+        profile.setId(id);
         dao.update(profile);
     }
 


### PR DESCRIPTION
### Summary
- Introduced ProfileSaveDto for create/update payload.
- Added ProfileSaveRequestMapper (HttpServletRequest → ProfileSaveDto) with validation & 400 on bad input.
- Added ProfileMapper (ProfileSaveDto → Profile entity) for the service layer.
- ProfileService now accepts SaveDto in save/update and maps to entity internally.
- ProfileController POST/PUT simplified: parse request → dto, call service (id from URL for PUT).