### PR TITLE
feat(profile): add findByIdOrThrow; unify GET/PUT error handling; tighten email update

### DIFF
--- a/src/ru/andrewb/charm/back/controller/EmailController.java
+++ b/src/ru/andrewb/charm/back/controller/EmailController.java
@@ -7,7 +7,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import ru.andrewb.charm.back.dto.ProfileGetDto;
 import ru.andrewb.charm.back.mapper.RequestToProfileUpdateDtoMapper;
 import ru.andrewb.charm.back.model.exception.BadRequestException;
 import ru.andrewb.charm.back.model.exception.DuplicateEmailException;
@@ -16,7 +15,6 @@ import ru.andrewb.charm.back.service.ProfileService;
 import ru.andrewb.charm.back.utils.RequestParams;
 
 import java.io.IOException;
-import java.util.Optional;
 
 @WebServlet("/email")
 public class EmailController extends HttpServlet {
@@ -29,37 +27,27 @@ public class EmailController extends HttpServlet {
 
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
-        long id;
         try {
-            id = RequestParams.requirePositiveLong(req, "id");
+            long id = RequestParams.requirePositiveLong(req, "id");
+            var dto = service.findByIdOrThrow(id);
+            req.setAttribute("profile", dto);
+            req.getRequestDispatcher("/WEB-INF/jsp/email.jsp").forward(req, resp);
         } catch (BadRequestException e) {
             resp.sendError(HttpServletResponse.SC_BAD_REQUEST, e.getMessage());
-            return;
+        } catch (NotFoundException e) {
+            resp.sendError(HttpServletResponse.SC_NOT_FOUND, e.getMessage());
         }
-
-        Optional<ProfileGetDto> profileDtoOptional = service.findById(id);
-        if (profileDtoOptional.isEmpty()) {
-            resp.sendError(HttpServletResponse.SC_NOT_FOUND, "Profile not found");
-            return;
-        }
-        req.setAttribute("profile", profileDtoOptional.get());
-        req.getRequestDispatcher("/WEB-INF/jsp/email.jsp").forward(req, resp);
     }
 
     @Override
     protected void doPut(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
-        long id;
         try {
-            id = RequestParams.requirePositiveLong(req, "id");
-        } catch (BadRequestException e) {
-            resp.sendError(HttpServletResponse.SC_BAD_REQUEST, e.getMessage());
-            return;
-        }
-
-        try {
+            long id = RequestParams.requirePositiveLong(req, "id");
             var dto = requestToProfileUpdateDtoMapper.map(req);
+
             service.update(id, dto);
-            log.info("[{}] Email changed: id={}, newEmail={}", rid(req), id, dto.getEmail());
+            log.info("[{}] Email changed: id={}", rid(req), id);
+
             resp.sendRedirect(req.getContextPath() + "/profile?id=" + id);
         } catch (NotFoundException e) {
             resp.sendError(HttpServletResponse.SC_NOT_FOUND, e.getMessage());

--- a/src/ru/andrewb/charm/back/controller/ProfileController.java
+++ b/src/ru/andrewb/charm/back/controller/ProfileController.java
@@ -9,7 +9,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import ru.andrewb.charm.back.dto.ProfileGetDto;
 import ru.andrewb.charm.back.mapper.RequestToProfileUpdateDtoMapper;
 import ru.andrewb.charm.back.model.Gender;
 import ru.andrewb.charm.back.model.Status;
@@ -20,7 +19,6 @@ import ru.andrewb.charm.back.service.ProfileService;
 import ru.andrewb.charm.back.utils.RequestParams;
 
 import java.io.IOException;
-import java.util.Optional;
 
 @WebServlet(value = "/profile", loadOnStartup = 1)
 public class ProfileController extends HttpServlet {
@@ -51,39 +49,28 @@ public class ProfileController extends HttpServlet {
             return;
         }
 
-        long id;
         try {
-            id = RequestParams.requirePositiveLong(req, "id");
+            long id = RequestParams.requirePositiveLong(req, "id");
+            var dto = service.findByIdOrThrow(id);
+            req.setAttribute("profile", dto);
+            req.getRequestDispatcher("/WEB-INF/jsp/profile.jsp").forward(req, resp);
         } catch (BadRequestException e) {
             resp.sendError(HttpServletResponse.SC_BAD_REQUEST, e.getMessage());
-            return;
+        } catch (NotFoundException e) {
+            resp.sendError(HttpServletResponse.SC_NOT_FOUND, e.getMessage());
         }
-
-        Optional<ProfileGetDto> profileDtoOptional = service.findById(id);
-        if (profileDtoOptional.isEmpty()) {
-            resp.sendError(HttpServletResponse.SC_NOT_FOUND, "Profile not found");
-            return;
-        }
-        req.setAttribute("profile", profileDtoOptional.get());
-        req.getRequestDispatcher("/WEB-INF/jsp/profile.jsp").forward(req, resp);
     }
 
     @Override
     protected void doPut(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
-        long id;
         try {
-            id = RequestParams.requirePositiveLong(req, "id");
-        } catch (BadRequestException e) {
-            resp.sendError(HttpServletResponse.SC_BAD_REQUEST, e.getMessage());
-            return;
-        }
-
-        try {
+            long id = RequestParams.requirePositiveLong(req, "id");
             var dto = requestToProfileUpdateDtoMapper.map(req);
+
             service.update(id, dto);
             log.info("[{}] Profile updated: id={}", rid(req), id);
-            String referer = req.getHeader("referer");
-            resp.sendRedirect(req.getContextPath() + referer);
+
+            resp.sendRedirect(req.getContextPath() + "/profile?id=" + id);
         } catch (NotFoundException e) {
             resp.sendError(HttpServletResponse.SC_NOT_FOUND, e.getMessage());
         } catch (BadRequestException e) {

--- a/src/ru/andrewb/charm/back/service/ProfileService.java
+++ b/src/ru/andrewb/charm/back/service/ProfileService.java
@@ -50,23 +50,36 @@ public class ProfileService {
         return dao.findById(id).map(profileToProfileGetDtoMapper::map);
     }
 
+    public ProfileGetDto findByIdOrThrow(long id) {
+        return dao.findById(id)
+                .map(profileToProfileGetDtoMapper::map)
+                .orElseThrow(() -> new NotFoundException("profile not found"));
+    }
+
     public List<ProfileGetDto> findAll() {
         return dao.findAll().stream().map(profileToProfileGetDtoMapper::map).toList();
     }
 
-    public void update(Long id, ProfileUpdateDto dto) {
+    public void update(long id, ProfileUpdateDto dto) {
         var existing = dao.findById(id)
                 .orElseThrow(() -> new NotFoundException("profile not found"));
 
+        String normalizedEmail = null;
         if (dto.getEmail() != null) {
-            String email = normalizeEmail(dto.getEmail());
-            requireValidEmail(email);
-            if (dao.existsEmail(email, id)) throw new DuplicateEmailException("email already exists");
-            dto.setEmail(email);
+            normalizedEmail = normalizeEmail(dto.getEmail());
+            requireValidEmail(normalizedEmail);
+
+            if (!normalizedEmail.equalsIgnoreCase(existing.getEmail())
+                    && dao.existsEmail(normalizedEmail, id)) {
+                throw new DuplicateEmailException("email already exists");
+            }
         }
 
         Profile profile = profileUpdateDtoToProfileMapper.map(dto, existing);
         profile.setId(id);
+        if (normalizedEmail != null) {
+            profile.setEmail(normalizedEmail);
+        }
 
         // TODO: БИЗНЕС-ПРАВИЛО (при переходе в ACTIVE требуем заполненность обязательных полей)
         dao.update(profile);


### PR DESCRIPTION
### Summary
- Service
  - Add `findByIdOrThrow(long)` → returns ProfileGetDto or throws `NotFoundException` .
  - `update(long, ProfileUpdateDto)`: normalize and validate e-mail; check uniqueness **only when e-mail actually changes**.
- Controllers
  - `EmailController`, `ProfileController`: use `RequestParams.requirePositiveLong` + `service.findByIdOrThrow`.
  - Consistent error responses: 400 (bad request) / 404 (not found) / 409 (conflict).
  - Redirect to canonical URL after update: `/profile?id=<id>`.