### PR TITLE
refactor(dto): remove id from ProfileUpdateDto (id comes from URL)

### DIFF
--- a/src/ru/andrewb/charm/back/dto/ProfileUpdateDto.java
+++ b/src/ru/andrewb/charm/back/dto/ProfileUpdateDto.java
@@ -1,90 +1,27 @@
 package ru.andrewb.charm.back.dto;
 
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
 import ru.andrewb.charm.back.model.Gender;
 import ru.andrewb.charm.back.model.Status;
 
 import java.time.LocalDate;
 
+@Getter
+@Setter
+@ToString(onlyExplicitlyIncluded = true)
 public class ProfileUpdateDto {
-    private Long id;
+    @ToString.Include
     private String email;
-    private String password;
+    @ToString.Include
     private String name;
+    @ToString.Include
     private String surname;
+    
+    private String password;
     private String about;
     private LocalDate birthDate;
     private Gender gender;
     private Status status;
-
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
-
-    public String getEmail() {
-        return email;
-    }
-
-    public void setEmail(String email) {
-        this.email = email;
-    }
-
-    public String getPassword() {
-        return password;
-    }
-
-    public void setPassword(String password) {
-        this.password = password;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    public String getSurname() {
-        return surname;
-    }
-
-    public void setSurname(String surname) {
-        this.surname = surname;
-    }
-
-    public String getAbout() {
-        return about;
-    }
-
-    public void setAbout(String about) {
-        this.about = about;
-    }
-
-    public LocalDate getBirthDate() {
-        return birthDate;
-    }
-
-    public void setBirthDate(LocalDate birthDate) {
-        this.birthDate = birthDate;
-    }
-
-    public Gender getGender() {
-        return gender;
-    }
-
-    public void setGender(Gender gender) {
-        this.gender = gender;
-    }
-
-    public Status getStatus() {
-        return status;
-    }
-
-    public void setStatus(Status status) {
-        this.status = status;
-    }
 }


### PR DESCRIPTION
### What
- Drop `id` field from ProfileUpdateDto.
- Service already uses `update(long id, ProfileUpdateDto dto)`; no behavior change.
- Mappers do not touch `id` (no code changes needed besides DTO removal).