### PR TITLE
feat(web): add HiddenHttpMethodFilter (PUT/DELETE override), move app-scope init, fix email form action

### DIFF
--- a/resources/WEB-INF/jsp/email.jsp
+++ b/resources/WEB-INF/jsp/email.jsp
@@ -9,9 +9,8 @@
 <%@ include file="header.jsp" %>
 <div>
     <h3 style="color: red">${requestScope.wordBundle.getWord("email-warning")}</h3>
-    <form method="post" action="${pageContext.request.contextPath}/email">
+    <form method="post" action="${pageContext.request.contextPath}/email?id=${requestScope.profile.id}">
         <input type="hidden" name="_method" value="put"/>
-        <input type="hidden" name="id" value="${requestScope.profile.id}">
         <table>
             <tr>
                 <td><h3>${requestScope.wordBundle.getWord("email")}</h3></td>

--- a/src/ru/andrewb/charm/back/controller/ProfileController.java
+++ b/src/ru/andrewb/charm/back/controller/ProfileController.java
@@ -1,7 +1,5 @@
 package ru.andrewb.charm.back.controller;
 
-import jakarta.servlet.ServletConfig;
-import jakarta.servlet.ServletContext;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.annotation.WebServlet;
 import jakarta.servlet.http.HttpServlet;
@@ -9,8 +7,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
 import ru.andrewb.charm.back.mapper.RequestToProfileUpdateDtoMapper;
-import ru.andrewb.charm.back.model.Gender;
-import ru.andrewb.charm.back.model.Status;
 import ru.andrewb.charm.back.model.exception.BadRequestException;
 import ru.andrewb.charm.back.model.exception.DuplicateEmailException;
 import ru.andrewb.charm.back.model.exception.NotFoundException;
@@ -19,23 +15,12 @@ import ru.andrewb.charm.back.utils.RequestParams;
 
 import java.io.IOException;
 
-@WebServlet(value = "/profile", loadOnStartup = 1)
+@WebServlet("/profile")
 @Slf4j
 public class ProfileController extends HttpServlet {
 
     private final ProfileService service = ProfileService.getInstance();
     private final RequestToProfileUpdateDtoMapper requestToProfileUpdateDtoMapper = RequestToProfileUpdateDtoMapper.getInstance();
-
-    @Override
-    public void init(ServletConfig config) throws ServletException {
-        ServletContext servletContext = config.getServletContext();
-        if (servletContext.getAttribute("genders") == null) {
-            servletContext.setAttribute("genders", Gender.values());
-        }
-        if (servletContext.getAttribute("statuses") == null) {
-            servletContext.setAttribute("statuses", Status.values());
-        }
-    }
 
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {

--- a/src/ru/andrewb/charm/back/controller/filter/HiddenHttpMethodFilter.java
+++ b/src/ru/andrewb/charm/back/controller/filter/HiddenHttpMethodFilter.java
@@ -5,29 +5,43 @@ import jakarta.servlet.annotation.WebFilter;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletRequestWrapper;
 import jakarta.servlet.http.HttpServletResponse;
+import ru.andrewb.charm.back.model.Gender;
+import ru.andrewb.charm.back.model.Status;
 
 import java.io.IOException;
 import java.util.Locale;
 
-@WebFilter("/*")
+@WebFilter(value = "/*", dispatcherTypes = DispatcherType.REQUEST)
 public class HiddenHttpMethodFilter implements Filter {
 
     public static final String METHOD_PARAM = "_method";
+
+    @Override
+    public void init(FilterConfig config) {
+        ServletContext servletContext = config.getServletContext();
+        if (servletContext.getAttribute("genders") == null) {
+            servletContext.setAttribute("genders", Gender.values());
+        }
+        if (servletContext.getAttribute("statuses") == null) {
+            servletContext.setAttribute("statuses", Status.values());
+        }
+    }
 
     @Override
     public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain) throws IOException, ServletException {
         HttpServletRequest req = (HttpServletRequest) servletRequest;
         HttpServletResponse resp = (HttpServletResponse) servletResponse;
 
-        String paramValue = req.getParameter(METHOD_PARAM);
-
-        if ("POST".equals(req.getMethod()) && paramValue != null && !paramValue.isBlank()) {
-            String method = paramValue.toUpperCase(Locale.ENGLISH);
-            HttpServletRequest wrapper = new HttpMethodRequestWrapper(req, method);
-            filterChain.doFilter(wrapper, resp);
-        } else {
-            filterChain.doFilter(req, resp);
+        String override = req.getParameter(METHOD_PARAM);
+        if ("POST".equalsIgnoreCase(req.getMethod()) && override != null && !override.isBlank()) {
+            String method = override.toUpperCase(Locale.ENGLISH);
+            if (method.equals("PUT") || method.equals("DELETE")) {
+                HttpServletRequest wrapped = new HttpMethodRequestWrapper(req, method);
+                filterChain.doFilter(wrapped, resp);
+                return;
+            }
         }
+        filterChain.doFilter(req, resp);
     }
 
     private static class HttpMethodRequestWrapper extends HttpServletRequestWrapper {
@@ -44,6 +58,4 @@ public class HiddenHttpMethodFilter implements Filter {
             return this.method;
         }
     }
-
-
 }


### PR DESCRIPTION
### Summary
- HiddenHttpMethodFilter:
  - Registered for DispatcherType.REQUEST only.
  - Looks for _method on POST requests and, if present and valid (PUT/DELETE), wraps the request so getMethod() reflects the override.
  - Uses an allow-list for safety; any other value leaves the request as plain POST.
  - Also moves app-scope initialization (genders, statuses) to filter.init() to avoid duplication and ordering issues.
- ProfileController:
  - Removed the previous app-scope init from the controller (and the need for loadOnStartup), since it now lives in the filter.
- email.jsp:
  - Sends id as a query parameter in the form action (e.g., /email?id=${profile.id}) and drops the hidden id field. This guarantees the controller sees the id via getParameter(...) even on PUT.