### PR TITLE
feat(profile): add photo upload + secure content serving

### DIFF
--- a/resources/WEB-INF/jsp/profile.jsp
+++ b/resources/WEB-INF/jsp/profile.jsp
@@ -8,7 +8,7 @@
     <body>
         <%@ include file="header.jsp" %>
         <div>
-            <form method="post" action="${pageContext.request.contextPath}/profile">
+            <form method="post" action="${pageContext.request.contextPath}/profile" enctype="multipart/form-data">
                 <input type="hidden" name="_method" value="PUT">
                 <input type="hidden" name="id" value="${profile.id}">
                 <table>
@@ -56,6 +56,19 @@
                                     </option>
                                 </c:forEach>
                             </select>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td><h3>${wordBundle.getWord("photo")}</h3></td>
+                        <td>
+                            <c:if test="${not empty profile.photo}">
+                                <img src="${pageContext.request.contextPath}/content/profile/${profile.id}/${profile.photo}"
+                                     alt="photo" height="300">
+                            </c:if>
+                            <br>
+                            <input type="button" value="${wordBundle.getWord('update')}"
+                                   onclick="document.getElementById('file').click();"/>
+                            <input type="file" name="photo" id="file" accept="image/*" style="display:none;">
                         </td>
                     </tr>
                 </table>

--- a/src/ru/andrewb/charm/back/controller/ContentController.java
+++ b/src/ru/andrewb/charm/back/controller/ContentController.java
@@ -1,0 +1,44 @@
+package ru.andrewb.charm.back.controller;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import ru.andrewb.charm.back.service.ContentService;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+@WebServlet("/content/*")
+public class ContentController extends HttpServlet {
+
+    public static final ContentService contentService = ContentService.getInstance();
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        String prefix = req.getContextPath() + "/content";
+        String contentPath = req.getRequestURI().substring(prefix.length());
+
+        String fileName = contentPath.substring(contentPath.lastIndexOf('/') + 1);
+        String mime = getServletContext().getMimeType(fileName);
+        resp.setContentType(mime != null ? mime : "application/octet-stream");
+
+        try {
+            if (contentPath.startsWith("/app/")) {
+                String appPath = "/WEB-INF" + contentPath.substring("/app".length());
+                try (InputStream in = getServletContext().getResourceAsStream(appPath)) {
+                    if (in == null) {
+                        resp.sendError(HttpServletResponse.SC_NOT_FOUND, "resource not found");
+                        return;
+                    }
+                    in.transferTo(resp.getOutputStream());
+                }
+            } else {
+                contentService.download(contentPath, resp.getOutputStream());
+            }
+        } catch (IOException e) {
+            resp.sendError(HttpServletResponse.SC_NOT_FOUND, "resource not found");
+        }
+    }
+}

--- a/src/ru/andrewb/charm/back/controller/ProfileController.java
+++ b/src/ru/andrewb/charm/back/controller/ProfileController.java
@@ -1,6 +1,7 @@
 package ru.andrewb.charm.back.controller;
 
 import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.MultipartConfig;
 import jakarta.servlet.annotation.WebServlet;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
@@ -21,6 +22,7 @@ import static ru.andrewb.charm.back.utils.RequestParams.rid;
 
 @WebServlet("/profile")
 @Slf4j
+@MultipartConfig
 public class ProfileController extends HttpServlet {
 
     private final ProfileService service = ProfileService.getInstance();

--- a/src/ru/andrewb/charm/back/dto/ProfileGetDto.java
+++ b/src/ru/andrewb/charm/back/dto/ProfileGetDto.java
@@ -27,4 +27,5 @@ public class ProfileGetDto {
     private LocalDate birthDate;
     private Gender gender;
     private Status status;
+    private String photo;
 }

--- a/src/ru/andrewb/charm/back/dto/ProfileUpdateDto.java
+++ b/src/ru/andrewb/charm/back/dto/ProfileUpdateDto.java
@@ -1,5 +1,6 @@
 package ru.andrewb.charm.back.dto;
 
+import jakarta.servlet.http.Part;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
@@ -18,10 +19,11 @@ public class ProfileUpdateDto {
     private String name;
     @ToString.Include
     private String surname;
-    
+
     private String password;
     private String about;
     private LocalDate birthDate;
     private Gender gender;
     private Status status;
+    private Part photo;
 }

--- a/src/ru/andrewb/charm/back/mapper/ProfileToProfileGetDtoMapper.java
+++ b/src/ru/andrewb/charm/back/mapper/ProfileToProfileGetDtoMapper.java
@@ -37,6 +37,7 @@ public class ProfileToProfileGetDtoMapper implements Mapper<Profile, ProfileGetD
         }
         dto.setGender(profile.getGender());
         dto.setStatus(profile.getStatus());
+        dto.setPhoto(profile.getPhoto());
         return dto;
     }
 }

--- a/src/ru/andrewb/charm/back/mapper/RequestToProfileUpdateDtoMapper.java
+++ b/src/ru/andrewb/charm/back/mapper/RequestToProfileUpdateDtoMapper.java
@@ -3,6 +3,7 @@ package ru.andrewb.charm.back.mapper;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import lombok.SneakyThrows;
 import ru.andrewb.charm.back.dto.ProfileUpdateDto;
 import ru.andrewb.charm.back.model.Gender;
 import ru.andrewb.charm.back.model.Status;
@@ -27,6 +28,7 @@ public class RequestToProfileUpdateDtoMapper implements Mapper<HttpServletReques
         return map(req, new ProfileUpdateDto());
     }
 
+    @SneakyThrows
     @Override
     public ProfileUpdateDto map(HttpServletRequest req, ProfileUpdateDto dto) {
         String email = req.getParameter("email");
@@ -63,9 +65,18 @@ public class RequestToProfileUpdateDtoMapper implements Mapper<HttpServletReques
                 throw new BadRequestException("status must be one of " + Arrays.toString(Status.values()));
             }
         }
+
+        String ct = req.getContentType();
+        if (ct != null && ct.toLowerCase().startsWith("multipart/")) {
+            try {
+                dto.setPhoto(req.getPart("photo"));
+            } catch (Exception ignore) {
+
+            }
+        }
+
         return dto;
     }
-
 
     private static String trimToNull(String s) {
         if (s == null) return null;

--- a/src/ru/andrewb/charm/back/model/Profile.java
+++ b/src/ru/andrewb/charm/back/model/Profile.java
@@ -25,4 +25,5 @@ public class Profile {
     private LocalDate birthDate;
     private Gender gender;
     private Status status;
+    private String photo;
 }

--- a/src/ru/andrewb/charm/back/service/ContentService.java
+++ b/src/ru/andrewb/charm/back/service/ContentService.java
@@ -1,0 +1,56 @@
+package ru.andrewb.charm.back.service;
+
+import jakarta.servlet.ServletOutputStream;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static java.nio.file.StandardOpenOption.CREATE;
+import static java.nio.file.StandardOpenOption.TRUNCATE_EXISTING;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class ContentService {
+
+    private static final ContentService INSTANCE = new ContentService();
+
+    public static ContentService getInstance() {
+        return INSTANCE;
+    }
+
+    public void upload(String contentPath, InputStream inputStream) throws IOException {
+        Path full = getAbsolutePath(contentPath);
+        Files.createDirectories(full.getParent());
+        try (InputStream in = inputStream;
+             OutputStream out = Files.newOutputStream(full, CREATE, TRUNCATE_EXISTING)) {
+            in.transferTo(out);
+        }
+    }
+    
+    public void download(String contentPath, ServletOutputStream out) throws IOException {
+        Path full = getAbsolutePath(contentPath);
+        if (!Files.exists(full)) throw new FileNotFoundException();
+        try (InputStream in = Files.newInputStream(full)) {
+            in.transferTo(out);
+            out.flush();
+        }
+    }
+
+    private Path getAbsolutePath(String contentPath) {
+        String basePath = "/Users/andrew/Downloads"; // TODO: move to config/ENV
+        Path base = Path.of(basePath).toAbsolutePath().normalize();
+
+        String clean = contentPath.startsWith("/") ? contentPath.substring(1) : contentPath;
+        Path full = base.resolve(clean).normalize();
+
+        if (!full.startsWith(base)) {
+            throw new SecurityException("invalid content path");
+        }
+        return full;
+    }
+}

--- a/src/ru/andrewb/charm/back/service/ProfileService.java
+++ b/src/ru/andrewb/charm/back/service/ProfileService.java
@@ -2,6 +2,7 @@ package ru.andrewb.charm.back.service;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import lombok.SneakyThrows;
 import ru.andrewb.charm.back.dao.ProfileDao;
 import ru.andrewb.charm.back.dto.ProfileGetDto;
 import ru.andrewb.charm.back.dto.ProfileUpdateDto;
@@ -15,6 +16,7 @@ import ru.andrewb.charm.back.model.exception.NotFoundException;
 import ru.andrewb.charm.back.utils.Emails;
 import ru.andrewb.charm.back.utils.Passwords;
 
+import java.nio.file.Paths;
 import java.util.List;
 import java.util.Optional;
 
@@ -24,6 +26,8 @@ public class ProfileService {
     private static final ProfileService INSTANCE = new ProfileService();
 
     private final ProfileDao dao = ProfileDao.getInstance();
+
+    private final ContentService contentService = ContentService.getInstance();
 
     private final ProfileToProfileGetDtoMapper profileToProfileGetDtoMapper = ProfileToProfileGetDtoMapper.getInstance();
 
@@ -64,6 +68,7 @@ public class ProfileService {
         return dao.findAll().stream().map(profileToProfileGetDtoMapper::map).toList();
     }
 
+    @SneakyThrows
     public void update(long id, ProfileUpdateDto dto) {
         var existing = dao.findById(id)
                 .orElseThrow(() -> new NotFoundException("profile not found"));
@@ -82,6 +87,13 @@ public class ProfileService {
         p.setId(id);
         if (newEmailNormalized != null) {
             p.setEmail(newEmailNormalized);
+        }
+
+        var part = dto.getPhoto();
+        if (part != null && part.getSize() > 0) {
+            String fileName = Paths.get(part.getSubmittedFileName()).getFileName().toString();
+            contentService.upload("/profile/" + id + "/" + fileName, part.getInputStream());
+            p.setPhoto(fileName);
         }
 
         // TODO: БИЗНЕС-ПРАВИЛО (при переходе в ACTIVE требуем заполненность обязательных полей)


### PR DESCRIPTION
### What
- Allow users to upload a profile photo and show it on the profile page.
- Serve both user-uploaded files and app-bundled assets via a dedicated controller.

### Changes
- UI (JSP):
  - `profile.jsp`: `enctype="multipart/form-data"`, file input, image preview:
    `/content/profile/{id}/{filename}`.
- DTOs:
  - `ProfileUpdateDto`: new `Part photo`.
  - `ProfileGetDto`: new `String photo`.
- Mappers:
  - `RequestToProfileUpdateDtoMapper`: read `photo` part when multipart request.
  - `ProfileToProfileGetDtoMapper`: map `Profile.photo` to DTO.
- Domain:
  - `Profile`: new `photo` field.
- Service:
  - `ProfileService.update(...)`: save photo when present; sanitize file name; keep email checks.
- Content:
  - `ContentController`: GET `/content/*` with MIME detection, `/content/app/*` for WAR resources.
  - `ContentService`: file upload/download; path normalization to prevent path traversal.

### Security/Hardening
- Path normalization and base directory pinning.
- MIME detection via file name.
- No overwrite of email/status logic.