### PR TITLE
fix(errors): show our localized error pages; clean profile form required flags

### DIFF
--- a/resources/WEB-INF/jsp/errors/400.jsp
+++ b/resources/WEB-INF/jsp/errors/400.jsp
@@ -1,15 +1,15 @@
 <%@ page contentType="text/html;charset=UTF-8" %>
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <html lang="${empty cookie.lang ? 'en' : cookie.lang.value}">
-    <head>
-        <title>Charm Bad Request</title>
-        <%@ include file="style.jsp" %>
-    </head>
-    <body>
-        <%@ include file="header.jsp" %>
-        <div>
-            <h3>400 - ${requestScope.wordBundle.getWord("page-bad-request")}</h3>
-        </div>
-        <%@ include file="footer.jsp" %>
-    </body>
+<head>
+    <title>Charm Bad Request</title>
+    <%@ include file="../style.jsp" %>
+</head>
+<body>
+<%@ include file="../header.jsp" %>
+<div>
+    <h3>400 - ${wordBundle.getWord("page-bad-request")}</h3>
+</div>
+<%@ include file="../footer.jsp" %>
+</body>
 </html>

--- a/resources/WEB-INF/jsp/errors/404.jsp
+++ b/resources/WEB-INF/jsp/errors/404.jsp
@@ -1,15 +1,15 @@
 <%@ page contentType="text/html;charset=UTF-8" %>
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <html lang="${empty cookie.lang ? 'en' : cookie.lang.value}">
-    <head>
-        <title>Charm Not Found</title>
-        <%@ include file="style.jsp" %>
-    </head>
-    <body>
-        <%@ include file="header.jsp" %>
-        <div>
-            <h3>404 - ${requestScope.wordBundle.getWord("page-not-found")}</h3>
-        </div>
-        <%@ include file="footer.jsp" %>
-    </body>
+<head>
+    <title>Charm Not Found</title>
+    <%@ include file="../style.jsp" %>
+</head>
+<body>
+<%@ include file="../header.jsp" %>
+<div>
+    <h3>404 - ${wordBundle.getWord("page-not-found")}</h3>
+</div>
+<%@ include file="../footer.jsp" %>
+</body>
 </html>

--- a/resources/WEB-INF/jsp/errors/409.jsp
+++ b/resources/WEB-INF/jsp/errors/409.jsp
@@ -1,15 +1,15 @@
 <%@ page contentType="text/html;charset=UTF-8" %>
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <html lang="${empty cookie.lang ? 'en' : cookie.lang.value}">
-    <head>
-        <title>Charm Conflict</title>
-        <%@ include file="style.jsp" %>
-    </head>
-    <body>
-        <%@ include file="header.jsp" %>
-        <div>
-            <h3>409 - ${requestScope.wordBundle.getWord("page-conflict")}</h3>
-        </div>
-        <%@ include file="footer.jsp" %>
-    </body>
+<head>
+    <title>Charm Conflict</title>
+    <%@ include file="../style.jsp" %>
+</head>
+<body>
+<%@ include file="../header.jsp" %>
+<div>
+    <h3>409 - ${wordBundle.getWord("page-conflict")}</h3>
+</div>
+<%@ include file="../footer.jsp" %>
+</body>
 </html>

--- a/resources/WEB-INF/jsp/errors/500.jsp
+++ b/resources/WEB-INF/jsp/errors/500.jsp
@@ -1,15 +1,15 @@
 <%@ page contentType="text/html;charset=UTF-8" %>
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <html lang="${empty cookie.lang ? 'en' : cookie.lang.value}">
-    <head>
-        <title>Charm Unexpected error</title>
-        <%@ include file="style.jsp" %>
-    </head>
-    <body>
-        <%@ include file="header.jsp" %>
-        <div>
-            <h3>500 - ${requestScope.wordBundle.getWord("unexpected-error")}</h3>
-        </div>
-        <%@ include file="footer.jsp" %>
-    </body>
+<head>
+    <title>Charm Unexpected error</title>
+    <%@ include file="../style.jsp" %>
+</head>
+<body>
+<%@ include file="../header.jsp" %>
+<div>
+    <h3>500 - ${wordBundle.getWord("unexpected-error")}</h3>
+</div>
+<%@ include file="../footer.jsp" %>
+</body>
 </html>

--- a/resources/WEB-INF/jsp/profile.jsp
+++ b/resources/WEB-INF/jsp/profile.jsp
@@ -38,14 +38,14 @@
                     </c:if>
                     <tr>
                         <td><h3>${wordBundle.getWord("about")}</h3></td>
-                        <td><input type="text" name="about" required
+                        <td><input type="text" name="about"
                                    value="${(fields != null && fields['about'] != null) ? fields['about'] : profile.about}"></td>
                     </tr>
                     <tr>
                         <td><h3>${wordBundle.getWord("gender")}</h3></td>
                         <td>
                             <c:set var="g" value="${profile.gender}"/>
-                            <select name="gender" required>
+                            <select name="gender">
                                 <option value="" disabled <c:if test="${empty g}">selected</c:if>>
                                     ${wordBundle.getWord("select-gender")}
                                 </option>


### PR DESCRIPTION
### Summary
- Make custom error pages (400/404/409/500) include header/footer/style via correct relative paths.
- Remove HTML `required` from Profile fields that aren't mandatory yet (about, gender).