### PR TITLE
PostgreSQL migration: ProfileDao, unified JDBC style, and birthdate rename

### DIFF
--- a/resources/WEB-INF/jsp/profile.jsp
+++ b/resources/WEB-INF/jsp/profile.jsp
@@ -27,10 +27,10 @@
                     </tr>
                     <tr>
                         <td><h3>${wordBundle.getWord("birthdate")}</h3></td>
-                        <td><input type="date" name="birthDate"
-                                   value="${profile.birthDate}"></td>
+                        <td><input type="date" name="birthdate"
+                                   value="${profile.birthdate}"></td>
                     </tr>
-                    <c:if test="${!empty profile.birthDate}">
+                    <c:if test="${!empty profile.birthdate}">
                         <tr>
                             <td><h3>${wordBundle.getWord("age")}</h3></td>
                             <td><h3>${profile.age}</h3></td>

--- a/src/ru/andrewb/charm/back/controller/LoginController.java
+++ b/src/ru/andrewb/charm/back/controller/LoginController.java
@@ -60,8 +60,8 @@ public class LoginController extends HttpServlet {
                 return;
             }
 
-            log.info("[{}] Login ok: email={}", rid(req), dto.getEmail());
             var userDetails = service.login(dto);
+            log.info("[{}] Login ok: email={}", rid(req), dto.getEmail());
             req.getSession().setAttribute("userDetails", userDetails);
             resp.sendRedirect(req.getContextPath() + PROFILE_URL + "?id=" + userDetails.getId());
 

--- a/src/ru/andrewb/charm/back/controller/RegistrationController.java
+++ b/src/ru/andrewb/charm/back/controller/RegistrationController.java
@@ -54,8 +54,8 @@ public class RegistrationController extends HttpServlet {
                 return;
             }
 
-            log.info("[{}] Registration ok: email={}", rid(req), dto.getEmail());
             service.save(dto);
+            log.info("[{}] Registration ok: email={}", rid(req), dto.getEmail());
             resp.sendRedirect(req.getContextPath() + LOGIN_URL);
 
         } catch (BadRequestException e) {

--- a/src/ru/andrewb/charm/back/dao/ProfileDao.java
+++ b/src/ru/andrewb/charm/back/dao/ProfileDao.java
@@ -1,99 +1,215 @@
 package ru.andrewb.charm.back.dao;
 
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import lombok.SneakyThrows;
 import ru.andrewb.charm.back.model.Gender;
 import ru.andrewb.charm.back.model.Profile;
 import ru.andrewb.charm.back.model.Role;
 import ru.andrewb.charm.back.model.Status;
 
-import java.time.LocalDate;
+import java.sql.*;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicLong;
 
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class ProfileDao {
 
     private static final ProfileDao INSTANCE = new ProfileDao();
 
-    private final ConcurrentHashMap<Long, Profile> storage;
-    private final AtomicLong idStorage;
+    private static final String URL = "jdbc:postgresql://localhost:5434/charm_repository";
+    private static final String USER = "postgres";
+    private static final String PASSWORD = "1546";
 
-    private ProfileDao() {
-        this.storage = new ConcurrentHashMap<>();
+    // SQL
+    private static final String SQL_INSERT =
+            "insert into profile(email, password) values (?, ?) returning id";
+    private static final String SQL_FIND_BY_ID =
+            "select * from profile where id = ?";
+    private static final String SQL_FIND_BY_EMAIL =
+            "select * from profile where email = ?";
+    private static final String SQL_FIND_ALL =
+            "select * from profile order by id";
+    private static final String SQL_DELETE_BY_ID =
+            "delete from profile where id = ?";
+    private static final String SQL_EXISTS_EMAIL =
+            "select 1 from profile where email = ?";
+    private static final String SQL_EXISTS_EMAIL_EXCLUDING_ID =
+            "select 1 from profile where email = ? and id <> ?";
 
-        Profile profile1 = new Profile();
-        profile1.setId(1L);
-        profile1.setEmail("ivanov@mail.ru");
-        profile1.setPassword("123");
-        profile1.setName("Ivan");
-        profile1.setSurname("Ivanov");
-        profile1.setBirthDate(LocalDate.parse("2007-12-03"));
-        profile1.setAbout("I am QA");
-        profile1.setGender(Gender.MALE);
-        profile1.setStatus(Status.ACTIVE);
-        profile1.setRole(Role.ADMIN);
-        this.storage.put(1L, profile1);
 
-        Profile profile2 = new Profile();
-        profile2.setId(2L);
-        profile2.setEmail("sidorova@mail.ru");
-        profile2.setPassword("456");
-        profile2.setName("Elena");
-        profile2.setSurname("Sidorova");
-        profile2.setBirthDate(LocalDate.parse("2004-02-03"));
-        profile2.setAbout("I am Java Dev");
-        profile2.setGender(Gender.FEMALE);
-        profile2.setStatus(Status.ACTIVE);
-        profile2.setRole(Role.USER);
-        this.storage.put(2L, profile2);
-
-        this.idStorage = new AtomicLong(3L);
-    }
-
+    @SneakyThrows
     public static ProfileDao getInstance() {
+        Class.forName("org.postgresql.Driver");
         return INSTANCE;
     }
 
     public Profile save(Profile profile) {
-        profile.setId(idStorage.getAndIncrement());
-        storage.put(profile.getId(), profile);
-        return profile;
+        try (Connection conn = DriverManager.getConnection(URL, USER, PASSWORD);
+             PreparedStatement ps = conn.prepareStatement(SQL_INSERT)) {
+            ps.setString(1, profile.getEmail());
+            ps.setString(2, profile.getPassword());
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    profile.setId(rs.getLong(1));
+                }
+            }
+            return profile;
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     public Optional<Profile> findById(Long id) {
-        return Optional.ofNullable(storage.get(id));
-    }
-
-    public List<Profile> findAll() {
-        return new ArrayList<>(storage.values());
-    }
-
-    public void update(Profile profile) {
-        Long id = profile.getId();
-        if (id == null) return;
-        storage.put(id, profile);
-    }
-
-    public boolean delete(Long id) {
-        return (storage.remove(id) != null);
-    }
-
-    public boolean existsEmail(String email, Long excludeId) {
-        if (email == null) return false;
-        String probe = email.trim();
-        return storage.values().stream().anyMatch(p ->
-                p.getEmail() != null
-                        && p.getEmail().equalsIgnoreCase(probe)
-                        && (excludeId == null || !p.getId().equals(excludeId))
-        );
+        try (Connection conn = DriverManager.getConnection(URL, USER, PASSWORD);
+             PreparedStatement ps = conn.prepareStatement(SQL_FIND_BY_ID)) {
+            ps.setLong(1, id);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    return Optional.of(mapToProfile(rs));
+                }
+                return Optional.empty();
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     public Optional<Profile> findByEmail(String email) {
-        if (email == null) return Optional.empty();
-        String probe = email.trim();
-        return storage.values().stream()
-                .filter(p -> p.getEmail() != null && p.getEmail().equalsIgnoreCase(probe))
-                .findFirst();
+        try (Connection conn = DriverManager.getConnection(URL, USER, PASSWORD);
+             PreparedStatement ps = conn.prepareStatement(SQL_FIND_BY_EMAIL)) {
+            ps.setString(1, email);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    return Optional.of(mapToProfile(rs));
+                }
+                return Optional.empty();
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public List<Profile> findAll() {
+        try (Connection conn = DriverManager.getConnection(URL, USER, PASSWORD);
+             PreparedStatement ps = conn.prepareStatement(SQL_FIND_ALL);
+             ResultSet rs = ps.executeQuery()) {
+            List<Profile> profiles = new ArrayList<>();
+            while (rs.next()) {
+                profiles.add(mapToProfile(rs));
+            }
+            return profiles;
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public void update(Profile profile) {
+        StringBuilder sql = new StringBuilder("update profile set email = ?, password = ?");
+        List<Object> args = new ArrayList<>();
+        args.add(profile.getEmail());
+        args.add(profile.getPassword());
+
+        if (profile.getName() != null) {
+            sql.append(", name = ?");
+            args.add(profile.getName());
+        }
+        if (profile.getSurname() != null) {
+            sql.append(", surname = ?");
+            args.add(profile.getSurname());
+        }
+        if (profile.getBirthdate() != null) {
+            sql.append(", birthdate = ?");
+            args.add(Date.valueOf(profile.getBirthdate()));
+        }
+        if (profile.getAbout() != null) {
+            sql.append(", about = ?");
+            args.add(profile.getAbout());
+        }
+        if (profile.getGender() != null) {
+            sql.append(", gender = ?");
+            args.add(profile.getGender().name());
+        }
+        if (profile.getStatus() != null) {
+            sql.append(", status = ?");
+            args.add(profile.getStatus().name());
+        }
+        if (profile.getPhoto() != null) {
+            sql.append(", photo = ?");
+            args.add(profile.getPhoto());
+        }
+
+        sql.append(" where id = ?");
+        args.add(profile.getId());
+
+        try (Connection conn = DriverManager.getConnection(URL, USER, PASSWORD);
+             PreparedStatement ps = conn.prepareStatement(sql.toString())) {
+            for (int i = 0; i < args.size(); i++) {
+                ps.setObject(i + 1, args.get(i));
+            }
+            ps.executeUpdate();
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public boolean delete(Long id) {
+        try (Connection conn = DriverManager.getConnection(URL, USER, PASSWORD);
+             PreparedStatement ps = conn.prepareStatement(SQL_DELETE_BY_ID)) {
+            ps.setLong(1, id);
+            int deleted = ps.executeUpdate();
+            return deleted > 0;
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public boolean existsEmail(String email, Long excludeId) {
+        final String sql = (excludeId == null) ? SQL_EXISTS_EMAIL : SQL_EXISTS_EMAIL_EXCLUDING_ID;
+
+        try (Connection conn = DriverManager.getConnection(URL, USER, PASSWORD);
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setString(1, email);
+            if (excludeId != null) {
+                ps.setLong(2, excludeId);
+            }
+            try (ResultSet rs = ps.executeQuery()) {
+                return rs.next();
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private Profile mapToProfile(ResultSet rs) throws SQLException {
+        Profile p = new Profile();
+        p.setId(rs.getLong("id"));
+        p.setEmail(rs.getString("email"));
+        p.setPassword(rs.getString("password"));
+        p.setName(rs.getString("name"));
+        p.setSurname(rs.getString("surname"));
+
+        Date birthdate = rs.getDate("birthdate");
+        if (birthdate != null) {
+            p.setBirthdate(birthdate.toLocalDate());
+        }
+        p.setAbout(rs.getString("about"));
+        p.setPhoto(rs.getString("photo"));
+
+        String gender = rs.getString("gender");
+        if (gender != null) {
+            p.setGender(Gender.valueOf(gender.toUpperCase(Locale.ROOT)));
+        }
+        String status = rs.getString("status");
+        if (status != null) {
+            p.setStatus(Status.valueOf(status.toUpperCase(Locale.ROOT)));
+        }
+        String role = rs.getString("role");
+        if (role != null) {
+            p.setRole(Role.valueOf(role.toUpperCase(Locale.ROOT)));
+        }
+        return p;
     }
 }

--- a/src/ru/andrewb/charm/back/dto/ProfileGetDto.java
+++ b/src/ru/andrewb/charm/back/dto/ProfileGetDto.java
@@ -28,7 +28,7 @@ public class ProfileGetDto {
     Integer age;
 
     String about;
-    LocalDate birthDate;
+    LocalDate birthdate;
     Gender gender;
     Status status;
     String photo;

--- a/src/ru/andrewb/charm/back/dto/ProfileUpdateDto.java
+++ b/src/ru/andrewb/charm/back/dto/ProfileUpdateDto.java
@@ -22,7 +22,7 @@ public class ProfileUpdateDto {
     String surname;
 
     String about;
-    LocalDate birthDate;
+    LocalDate birthdate;
     Gender gender;
     Status status;
     Part photo;

--- a/src/ru/andrewb/charm/back/mapper/ProfileToProfileGetDtoMapper.java
+++ b/src/ru/andrewb/charm/back/mapper/ProfileToProfileGetDtoMapper.java
@@ -29,9 +29,9 @@ public class ProfileToProfileGetDtoMapper implements Mapper<Profile, ProfileGetD
         dto.setName(profile.getName());
         dto.setSurname(profile.getSurname());
         dto.setAbout(profile.getAbout());
-        dto.setBirthDate(profile.getBirthDate());
-        if (profile.getBirthDate() != null) {
-            dto.setAge(Math.toIntExact(ChronoUnit.YEARS.between(profile.getBirthDate(), LocalDate.now())));
+        dto.setBirthdate(profile.getBirthdate());
+        if (profile.getBirthdate() != null) {
+            dto.setAge(Math.toIntExact(ChronoUnit.YEARS.between(profile.getBirthdate(), LocalDate.now())));
         } else {
             dto.setAge(null);
         }

--- a/src/ru/andrewb/charm/back/mapper/ProfileUpdateDtoToProfileMapper.java
+++ b/src/ru/andrewb/charm/back/mapper/ProfileUpdateDtoToProfileMapper.java
@@ -23,7 +23,7 @@ public class ProfileUpdateDtoToProfileMapper implements Mapper<ProfileUpdateDto,
     public Profile map(ProfileUpdateDto dto, Profile profile) {
         if (dto.getName() != null) profile.setName(dto.getName());
         if (dto.getSurname() != null) profile.setSurname(dto.getSurname());
-        if (dto.getBirthDate() != null) profile.setBirthDate(dto.getBirthDate());
+        if (dto.getBirthdate() != null) profile.setBirthdate(dto.getBirthdate());
         if (dto.getAbout() != null) profile.setAbout(dto.getAbout());
         if (dto.getGender() != null) profile.setGender(dto.getGender());
         if (dto.getStatus() != null) profile.setStatus(dto.getStatus());

--- a/src/ru/andrewb/charm/back/mapper/RegistrationDtoToProfileMapper.java
+++ b/src/ru/andrewb/charm/back/mapper/RegistrationDtoToProfileMapper.java
@@ -4,8 +4,6 @@ import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import ru.andrewb.charm.back.dto.RegistrationDto;
 import ru.andrewb.charm.back.model.Profile;
-import ru.andrewb.charm.back.model.Role;
-import ru.andrewb.charm.back.model.Status;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class RegistrationDtoToProfileMapper implements Mapper<RegistrationDto, Profile> {
@@ -25,8 +23,6 @@ public class RegistrationDtoToProfileMapper implements Mapper<RegistrationDto, P
     public Profile map(RegistrationDto dto, Profile profile) {
         profile.setEmail(dto.getEmail());
         profile.setPassword(dto.getPassword());
-        profile.setStatus(Status.INACTIVE);
-        profile.setRole(Role.USER);
         return profile;
     }
 }

--- a/src/ru/andrewb/charm/back/mapper/RequestToProfileUpdateDtoMapper.java
+++ b/src/ru/andrewb/charm/back/mapper/RequestToProfileUpdateDtoMapper.java
@@ -36,10 +36,10 @@ public class RequestToProfileUpdateDtoMapper implements Mapper<HttpServletReques
         dto.setSurname(stripToNull(req.getParameter("surname")));
         dto.setAbout(stripToNull(req.getParameter("about")));
 
-        String bd = stripToNull(req.getParameter("birthDate"));
+        String bd = stripToNull(req.getParameter("birthdate"));
         if (bd != null) {
             try {
-                dto.setBirthDate(LocalDate.parse(bd));
+                dto.setBirthdate(LocalDate.parse(bd));
             } catch (DateTimeParseException e) {
                 throw new BadRequestException("error.birthdate.format");
             }

--- a/src/ru/andrewb/charm/back/model/Profile.java
+++ b/src/ru/andrewb/charm/back/model/Profile.java
@@ -25,7 +25,7 @@ public class Profile {
 
     String password;
     String about;
-    LocalDate birthDate;
+    LocalDate birthdate;
     Gender gender;
     Status status;
     String photo;

--- a/src/ru/andrewb/charm/back/validator/ProfileUpdateValidator.java
+++ b/src/ru/andrewb/charm/back/validator/ProfileUpdateValidator.java
@@ -34,9 +34,9 @@ public class ProfileUpdateValidator implements Validator<ProfileUpdateDto> {
             vr.addError("error.about.too-long");
         }
 
-        if (dto.getBirthDate() != null) {
+        if (dto.getBirthdate() != null) {
             LocalDate today = LocalDate.now();
-            var bd = dto.getBirthDate();
+            var bd = dto.getBirthdate();
 
             if (bd.isAfter(today)) {
                 vr.addError("error.birthdate.future");


### PR DESCRIPTION
## Summary
Migrate persistence to PostgreSQL and unify JDBC style across DAO. Rename `birthDate` → `birthdate` in model/DTOs/mappers/views.

## What’s changed
- DB: PostgreSQL-backed `ProfileDao` (URL/user/pass), `INSERT ... RETURNING id`, parameterized queries.
- Style: consistent PreparedStatement usage; inner try-with-resources for ResultSet; SQL constants; `findAll` ordered by `id`.
- Domain: rename `birthDate` → `birthdate` in `Profile`, DTOs, validators, mappers, JSP.
- Controllers: minor logging order tidy-up.

## Breaking changes
- JSON/HTML field name is now `birthdate` (was `birthDate`). Clients must send/expect `birthdate`.
- DB schema required (see below).

## DB profile table structure
   ```sql
create table profile(
    id bigserial primary key,
    email varchar not null unique,
    password varchar not null,
    "name" varchar,
    surname varchar,
    birthdate date,
    about text,
    gender varchar,
    photo varchar,
    status varchar not null default 'INACTIVE',
    role varchar not null default 'USER',
    created_date timestamp not null default current_timestamp
);