### PR TITLE
rest: errors, logging, filter normalization

### DIFF
--- a/src/ru/andrewb/charm/back/controller/filter/ErrorFilter.java
+++ b/src/ru/andrewb/charm/back/controller/filter/ErrorFilter.java
@@ -7,6 +7,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
 import ru.andrewb.charm.back.mapper.JsonMapper;
 import ru.andrewb.charm.back.service.bundle.WordBundle;
+import ru.andrewb.charm.back.service.bundle.WordBundleEn;
 
 import java.io.IOException;
 import java.util.LinkedHashMap;
@@ -56,20 +57,31 @@ public class ErrorFilter implements Filter {
             if (code != null) body.put("code", code);
 
             WordBundle wb = (WordBundle) req.getAttribute("wordBundle");
-            if (msg != null && !msg.isBlank()) {
-                String outMsg = (wb != null && msg.startsWith("error."))
-                        ? wb.getWord(msg)
-                        : msg;
-                body.put("message", outMsg);
-            }
+            if (wb == null) wb = WordBundleEn.getInstance();
 
             Object errorsAttr = req.getAttribute("errors");
             if (errorsAttr instanceof List<?> list && !list.isEmpty()) {
                 List<String> errors = list.stream()
                         .map(String::valueOf)
-                        .map(codeStr -> wb != null ? wb.getWord(codeStr) : codeStr)
+                        .map(wb::getWord)
                         .toList();
                 body.put("errors", errors);
+            } else {
+                String outMsg = null;
+                if (msg != null && !msg.isBlank()) {
+                    if (msg.startsWith("error.")) {
+                        outMsg = wb.getWord(msg);
+                    } else {
+                        if (code != null && code < 500) outMsg = msg;
+                    }
+                }
+
+                if (outMsg == null) {
+                    String key = (code != null && code >= 500) ? "error.internal" : "error.param.invalid";
+                    outMsg = wb.getWord(key);
+                }
+
+                body.put("message", outMsg);
             }
 
             if (code != null) resp.setStatus(code);

--- a/src/ru/andrewb/charm/back/controller/filter/RequestLoggingFilter.java
+++ b/src/ru/andrewb/charm/back/controller/filter/RequestLoggingFilter.java
@@ -18,7 +18,6 @@ public class RequestLoggingFilter implements Filter {
         HttpServletRequest req = (HttpServletRequest) servletRequest;
         HttpServletResponse resp = (HttpServletResponse) servletResponse;
 
-        long start = System.currentTimeMillis();
         String rid = UUID.randomUUID().toString().substring(0, 8);
 
         req.setAttribute("rid", rid);
@@ -29,11 +28,17 @@ public class RequestLoggingFilter implements Filter {
         String method = req.getMethod();
 
         log.info("[{}] -> {} {}{}", rid, method, uri, (qs == null ? "" : "?" + qs));
+
+        long start = System.currentTimeMillis();
+        int status = 200;
         try {
             filterChain.doFilter(req, resp);
+            status = resp.getStatus();
+        } catch (Throwable t) {
+            status = 500;
+            throw t;
         } finally {
             long took = System.currentTimeMillis() - start;
-            int status = resp.getStatus();
             log.info("[{}] <- {} {} ({} ms)", rid, status, uri, took);
             MDC.clear();
         }

--- a/src/ru/andrewb/charm/back/controller/rest/LoginController.java
+++ b/src/ru/andrewb/charm/back/controller/rest/LoginController.java
@@ -41,12 +41,14 @@ public class LoginController extends HttpServlet {
             var userDetails = service.login(dto);
             req.getSession().setAttribute("userDetails", userDetails);
             resp.setStatus(HttpServletResponse.SC_NO_CONTENT);
+
         } catch (DatabindException e) {
-            req.setAttribute("errors", List.of(e.getLocalizedMessage(), e.getOriginalMessage()));
+            req.setAttribute("errors", List.of("error.param.invalid"));
             resp.sendError(HttpServletResponse.SC_BAD_REQUEST);
         } catch (BadRequestException e) {
             req.setAttribute("errors", List.of(e.getMessage()));
             resp.sendError(HttpServletResponse.SC_BAD_REQUEST);
+
         }
     }
 }

--- a/src/ru/andrewb/charm/back/controller/rest/ProfileController.java
+++ b/src/ru/andrewb/charm/back/controller/rest/ProfileController.java
@@ -41,21 +41,25 @@ public class ProfileController extends HttpServlet {
 
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
-        resp.setContentType("application/json;charset=UTF-8");
-        try (PrintWriter w = resp.getWriter()) {
+        try {
             long id = RequestParamUtils.requirePositiveLong(req, "id");
+
             var dtoOpt = service.findById(id);
             if (dtoOpt.isPresent()) {
-                jsonMapper.writeValue(w, dtoOpt.get());
-            } else {
-                req.setAttribute("errors", List.of("error.profile.not-found"));
-                resp.sendError(HttpServletResponse.SC_NOT_FOUND);
+                resp.setContentType("application/json;charset=UTF-8");
+                jsonMapper.writeValue(resp.getWriter(), dtoOpt.get());
+                return;
             }
+
+            req.setAttribute("errors", List.of("error.profile.not-found"));
+            resp.sendError(HttpServletResponse.SC_NOT_FOUND);
+
+        } catch (DatabindException e) {
+            req.setAttribute("errors", List.of("error.param.invalid"));
+            resp.sendError(HttpServletResponse.SC_BAD_REQUEST);
+
         } catch (BadRequestException e) {
             req.setAttribute("errors", List.of(e.getMessage()));
-            resp.sendError(HttpServletResponse.SC_BAD_REQUEST);
-        } catch (DatabindException e) {
-            req.setAttribute("errors", List.of(e.getLocalizedMessage(), e.getOriginalMessage()));
             resp.sendError(HttpServletResponse.SC_BAD_REQUEST);
         }
     }
@@ -78,10 +82,16 @@ public class ProfileController extends HttpServlet {
                     req.getContextPath() + PROFILE_REST_URL + "?id=" + id);
             resp.setContentType("application/json;charset=UTF-8");
             resp.getWriter().write("{\"id\":" + id + "}");
+
         } catch (DuplicateEmailException e) {
             req.setAttribute("errors", List.of(e.getMessage()));
             resp.sendError(HttpServletResponse.SC_CONFLICT);
-        } catch (BadRequestException | DatabindException e) {
+
+        } catch (DatabindException e) {
+            req.setAttribute("errors", List.of("error.param.invalid"));
+            resp.sendError(HttpServletResponse.SC_BAD_REQUEST);
+
+        } catch (BadRequestException e) {
             req.setAttribute("errors", List.of(e.getMessage()));
             resp.sendError(HttpServletResponse.SC_BAD_REQUEST);
         }
@@ -106,12 +116,15 @@ public class ProfileController extends HttpServlet {
         } catch (NotFoundException e) {
             req.setAttribute("errors", List.of(e.getMessage()));
             resp.sendError(HttpServletResponse.SC_NOT_FOUND);
+
+        } catch (DatabindException e) {
+            req.setAttribute("errors", List.of("error.param.invalid"));
+            resp.sendError(HttpServletResponse.SC_BAD_REQUEST);
+
         } catch (BadRequestException e) {
             req.setAttribute("errors", List.of(e.getMessage()));
             resp.sendError(HttpServletResponse.SC_BAD_REQUEST);
-        } catch (DatabindException e) {
-            req.setAttribute("errors", List.of(e.getLocalizedMessage(), e.getOriginalMessage()));
-            resp.sendError(HttpServletResponse.SC_BAD_REQUEST);
+
         }
     }
 

--- a/src/ru/andrewb/charm/back/controller/rest/ProfilesController.java
+++ b/src/ru/andrewb/charm/back/controller/rest/ProfilesController.java
@@ -9,6 +9,7 @@ import lombok.extern.slf4j.Slf4j;
 import ru.andrewb.charm.back.dto.ProfileFilter;
 import ru.andrewb.charm.back.mapper.JsonMapper;
 import ru.andrewb.charm.back.mapper.RequestToProfileFilterMapper;
+import ru.andrewb.charm.back.normalizer.ProfileFilterDefaults;
 import ru.andrewb.charm.back.service.ProfileService;
 
 import java.io.IOException;
@@ -27,12 +28,15 @@ public class ProfilesController extends HttpServlet {
 
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
-        resp.setContentType("application/json;charset=UTF-8");
-        try (PrintWriter w = resp.getWriter()) {
-            ProfileFilter filter = requestToProfileFilterMapper.map(req);
-            jsonMapper.writeValue(w, service.findAll(filter));
+        try {
+            ProfileFilter f = requestToProfileFilterMapper.map(req);
+            ProfileFilterDefaults.normalize(f);
+
+            resp.setContentType("application/json;charset=UTF-8");
+            jsonMapper.writeValue(resp.getWriter(), service.findAll(f));
+
         } catch (DatabindException e) {
-            req.setAttribute("errors", List.of(e.getLocalizedMessage(), e.getOriginalMessage()));
+            req.setAttribute("errors", List.of("error.param.invalid"));
             resp.sendError(HttpServletResponse.SC_BAD_REQUEST);
         }
     }

--- a/src/ru/andrewb/charm/back/service/ProfileService.java
+++ b/src/ru/andrewb/charm/back/service/ProfileService.java
@@ -13,6 +13,7 @@ import ru.andrewb.charm.back.model.exception.BadRequestException;
 import ru.andrewb.charm.back.model.exception.DuplicateEmailException;
 import ru.andrewb.charm.back.model.exception.NotFoundException;
 import ru.andrewb.charm.back.model.exception.StorageException;
+import ru.andrewb.charm.back.normalizer.ProfileFilterDefaults;
 import ru.andrewb.charm.back.utils.EmailUtils;
 import ru.andrewb.charm.back.utils.PasswordUtils;
 
@@ -63,6 +64,7 @@ public class ProfileService {
     }
 
     public List<ProfileGetDto> findAll(ProfileFilter filter) {
+        ProfileFilterDefaults.normalize(filter);
         return dao.findAll(filter).stream().map(profileToProfileGetDtoMapper::map).toList();
     }
 


### PR DESCRIPTION
Что сделано
 - Приведена обработка ошибок в REST-контроллерах к единому виду: выставляем errors, делаем sendError(...), ответ формирует ErrorFilter.
 - ErrorFilter отдаёт предсказуемый JSON для REST-ошибок (код + локализованные ошибки/сообщение).
 - RequestLoggingFilter улучшен: корректное логирование статуса и времени, rid в MDC.
 - Добавлена нормализация ProfileFilter на уровне сервиса, чтобы дефолты применялись даже если контроллер забудет.

Зачем
  •  REST-ответы на ошибки становятся стабильными и одинаковыми для всех эндпоинтов.
  •  Исключаем ситуации, когда контроллер случайно возвращает 200 при ошибке.
  •  Улучшаем диагностируемость по логам (rid, статус, latency).
  •  Гарантируем дефолты сортировки/пагинации на бизнес-уровне.