### PR TITLE
feat(charm): add redis empty cooldown to reduce DB load

### DIFF
--- a/resources/application.properties
+++ b/resources/application.properties
@@ -13,6 +13,8 @@ app.datasource.pool.acquire-timeout-ms=3000
 # --- Cache (Redis)
 app.redis.host=localhost
 app.redis.port=6379
+app.redis.charm-queue-ttl-sec=300
+app.redis.charm-empty-ttl-sec=60
 app.redis.timeout-ms=2000
 app.redis.pool.max-total=16
 app.redis.pool.max-idle=16

--- a/src/ru/andrewb/charm/back/service/CharmService.java
+++ b/src/ru/andrewb/charm/back/service/CharmService.java
@@ -18,7 +18,7 @@ public class CharmService {
 
     private final ProfileDao profileDao = ProfileDao.getInstance();
     private final ProfileLikeDao profileLikeDao = ProfileLikeDao.getInstance();
-    private final CacheService cacheService = CacheService.getInstance();
+    private final ProfileCacheService profileCacheService = ProfileCacheService.getInstance();
 
     public static CharmService getInstance() {
         return INSTANCE;
@@ -34,18 +34,33 @@ public class CharmService {
             profileLikeDao.likeOrDislike(fromId, toId, isLike);
         }
 
-        ProfileSimpleDto next = cacheService.pollNext(fromId);
+        // Try redis queue
+        ProfileSimpleDto next = profileCacheService.pollNext(fromId);
         if (next != null) {
             return Optional.of(next);
         }
 
+        // If "empty marker" active -> don't hit DB
+        if (profileCacheService.isEmptyCooldownActive(fromId)) {
+            return Optional.empty();
+        }
+
+        // Hit DB once per cooldown window
         Queue<ProfileSimpleDto> queue = profileDao.findSuitableForUser(fromId, 5);
         next = queue.poll();
 
-        if (!queue.isEmpty()) {
-            cacheService.replaceQueue(fromId, queue);
+        if (next == null) {  // no one
+            profileCacheService.markEmptyCooldown(fromId);
+            return Optional.empty();
         }
 
-        return Optional.ofNullable(next);
+        if (queue.isEmpty()) { // next exists, but queue empty again
+            profileCacheService.markEmptyCooldown(fromId);
+        } else {
+            profileCacheService.replaceQueue(fromId, queue);
+            profileCacheService.clearEmptyCooldown(fromId);
+        }
+
+        return Optional.of(next);
     }
 }

--- a/src/ru/andrewb/charm/back/service/ProfileCacheService.java
+++ b/src/ru/andrewb/charm/back/service/ProfileCacheService.java
@@ -10,20 +10,21 @@ import ru.andrewb.charm.back.utils.RedisManager;
 import java.util.Queue;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
-public class CacheService {
+public class ProfileCacheService {
 
-    private static final CacheService INSTANCE = new CacheService();
+    private static final ProfileCacheService INSTANCE = new ProfileCacheService();
 
-    private static final String QUEUE_PREFIX = "charm:queue: ";
+    private static final String QUEUE_KEY_PREFIX = "charm:queue:";
+    private static final String EMPTY_KEY_PREFIX = "charm:empty:";
 
     private final JsonMapper jsonMapper = JsonMapper.getInstance();
 
-    public static CacheService getInstance() {
+    public static ProfileCacheService getInstance() {
         return INSTANCE;
     }
 
     public ProfileSimpleDto pollNext(Long userId) {
-        String key = QUEUE_PREFIX + userId;
+        String key = QUEUE_KEY_PREFIX + userId;
         try (Jedis jedis = RedisManager.getResource()) {
             String json = jedis.lpop(key);
             if (json == null) return null;
@@ -34,7 +35,7 @@ public class CacheService {
     }
 
     public void replaceQueue(Long userId, Queue<ProfileSimpleDto> queue) {
-        String key = QUEUE_PREFIX + userId;
+        String key = QUEUE_KEY_PREFIX + userId;
         try (Jedis jedis = RedisManager.getResource()) {
             var p = jedis.pipelined();
             p.del(key);
@@ -43,10 +44,31 @@ public class CacheService {
                 String json = jsonMapper.writeValueAsString(dto);
                 p.rpush(key, json);
             }
-            p.expire(key, RedisManager.EXP_SEC);
+            p.expire(key, RedisManager.CHARM_QUEUE_TTL_SEC);
             p.sync();
         } catch (Exception e) {
             throw new RuntimeException("redis replaceQueue failed", e);
+        }
+    }
+
+    public boolean isEmptyCooldownActive(Long userId) {
+        String key = EMPTY_KEY_PREFIX + userId;
+        try (Jedis jedis = RedisManager.getResource()) {
+            return jedis.exists(key);
+        }
+    }
+
+    public void markEmptyCooldown(Long userId) {
+        String key = EMPTY_KEY_PREFIX + userId;
+        try (Jedis jedis = RedisManager.getResource()) {
+            jedis.setex(key, RedisManager.CHARM_EMPTY_TTL_SEC, "1");
+        }
+    }
+
+    public void clearEmptyCooldown(Long userId) {
+        String key = EMPTY_KEY_PREFIX + userId;
+        try (Jedis jedis = RedisManager.getResource()) {
+            jedis.del(key);
         }
     }
 }

--- a/src/ru/andrewb/charm/back/utils/RedisManager.java
+++ b/src/ru/andrewb/charm/back/utils/RedisManager.java
@@ -11,7 +11,10 @@ public class RedisManager {
     private static final String HOST = Config.required("app.redis.host");
     private static final int PORT = Integer.parseInt(Config.getOrDefault("app.redis.port", "6379"));
 
-    public static final int EXP_SEC = Integer.parseInt(Config.getOrDefault("app.redis.exp-sec", "300"));
+    public static final int CHARM_QUEUE_TTL_SEC =
+            Integer.parseInt(Config.getOrDefault("app.redis.charm-queue-ttl-sec", "300"));
+    public static final int CHARM_EMPTY_TTL_SEC =
+            Integer.parseInt(Config.getOrDefault("app.redis.charm-empty-ttl-sec", "60"));
 
     // pool tuning
     private static final int TIMEOUT_MS = Integer.parseInt(Config.getOrDefault("app.redis.timeout-ms", "2000"));


### PR DESCRIPTION
Что сделано
 - Переименован CacheService -> ProfileCacheService (чётче отражает назначение).
 - Добавлен empty marker (charm:empty:<userId>) с TTL, чтобы не дергать БД при частых "try again", когда кандидаты закончились.
 - TTL вынесены в конфиг:
   - app.redis.charm-queue-ttl-sec
   - app.redis.charm-empty-ttl-sec
 - В CharmService добавлена логика: сначала Redis-очередь -> затем проверка empty marker-> затем (редко) запрос в БД и наполнение очереди.

Зачем
  •  Снизить нагрузку на БД, когда у пользователя временно нет кандидатов и он спамит “Next/Try again”.
  •  Сделать поведение предсказуемым и управляемым через конфиг.