### PR TITLE
Prevent Charm queue refill races with Redis lock

### DIFF
--- a/resources/application.properties
+++ b/resources/application.properties
@@ -15,6 +15,7 @@ app.redis.host=localhost
 app.redis.port=6379
 app.redis.charm-queue-ttl-sec=300
 app.redis.charm-empty-ttl-sec=60
+app.redis.charm-lock-ttl-sec=3
 app.redis.timeout-ms=2000
 app.redis.pool.max-total=16
 app.redis.pool.max-idle=16

--- a/src/ru/andrewb/charm/back/service/CharmService.java
+++ b/src/ru/andrewb/charm/back/service/CharmService.java
@@ -45,19 +45,33 @@ public class CharmService {
             return Optional.empty();
         }
 
-        // Hit DB once per cooldown window
-        Queue<ProfileSimpleDto> queue = profileDao.findSuitableForUser(fromId, 5);
-        next = queue.poll();
-
-        if (next == null) {  // no one
-            profileCacheService.markEmptyCooldown(fromId);
+        // Try to acquire per-user refill lock
+        String token = profileCacheService.tryAcquireLock(fromId);
+        if (token == null) {
+            // Someone already refills thr queue now -> don't spam redis/db
             return Optional.empty();
         }
 
-        // at least 1 candidate
-        profileCacheService.clearEmptyCooldown(fromId);
-        if (!queue.isEmpty()) profileCacheService.replaceQueue(fromId, queue);
+        // Lock is free
+        try {
+            // Hit DB once per cooldown window
+            Queue<ProfileSimpleDto> queue = profileDao.findSuitableForUser(fromId, 5);
+            next = queue.poll();
 
-        return Optional.of(next);
+            if (next == null) {  // no one candidate
+                profileCacheService.markEmptyCooldown(fromId);
+                return Optional.empty();
+            }
+
+            // at least 1 candidate
+            profileCacheService.clearEmptyCooldown(fromId);
+            if (!queue.isEmpty()) profileCacheService.replaceQueue(fromId, queue);
+
+            return Optional.of(next);
+
+        } finally {
+            // Release lock safely
+            profileCacheService.releaseLock(fromId, token);
+        }
     }
 }

--- a/src/ru/andrewb/charm/back/service/ProfileCacheService.java
+++ b/src/ru/andrewb/charm/back/service/ProfileCacheService.java
@@ -3,11 +3,15 @@ package ru.andrewb.charm.back.service;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import redis.clients.jedis.Jedis;
+import redis.clients.jedis.params.SetParams;
 import ru.andrewb.charm.back.dto.ProfileSimpleDto;
 import ru.andrewb.charm.back.mapper.JsonMapper;
 import ru.andrewb.charm.back.utils.RedisManager;
 
 import java.util.Queue;
+import java.util.UUID;
+
+import static ru.andrewb.charm.back.utils.RedisManager.CHARM_LOCK_TTL_SEC;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class ProfileCacheService {
@@ -16,6 +20,7 @@ public class ProfileCacheService {
 
     private static final String QUEUE_KEY_PREFIX = "charm:queue:";
     private static final String EMPTY_KEY_PREFIX = "charm:empty:";
+    private static final String LOCK_KEY_PREFIX = "charm:lock:";
 
     private final JsonMapper jsonMapper = JsonMapper.getInstance();
 
@@ -23,8 +28,44 @@ public class ProfileCacheService {
         return INSTANCE;
     }
 
+    // --------------- lock ---------------
+    public String tryAcquireLock(Long userId) {
+        String lockKey = LOCK_KEY_PREFIX + userId;
+        String token = UUID.randomUUID().toString();
+
+        try (Jedis jedis = RedisManager.getResource()) {
+            String res = jedis.set(lockKey, token, SetParams.setParams().nx().ex(CHARM_LOCK_TTL_SEC));
+            return "OK".equals(res) ? token : null;
+        } catch (Exception e) {
+            throw new RuntimeException("redis tryAcquireLock failed", e);
+        }
+    }
+
+    public boolean releaseLock(Long userId, String token) {
+        if (token == null) return false;
+
+        String lockKey = LOCK_KEY_PREFIX + userId;
+
+        String lua = """
+                if redis.call('get', KEYS[1]) == ARGV[1] then
+                    return redis.call('del', KEYS[1])
+                else
+                    return 0
+                end
+                """;
+
+        try (Jedis jedis = RedisManager.getResource()) {
+            Object res = jedis.eval(lua, 1, lockKey, token);
+            return res.equals(1L);
+        } catch (Exception e) {
+            throw new RuntimeException("redis releaseLock failed", e);
+        }
+    }
+
+    // --------------- queue ---------------
     public ProfileSimpleDto pollNext(Long userId) {
         String key = QUEUE_KEY_PREFIX + userId;
+
         try (Jedis jedis = RedisManager.getResource()) {
             String json = jedis.lpop(key);
             if (json == null) return null;
@@ -36,6 +77,7 @@ public class ProfileCacheService {
 
     public void replaceQueue(Long userId, Queue<ProfileSimpleDto> queue) {
         String key = QUEUE_KEY_PREFIX + userId;
+
         try (Jedis jedis = RedisManager.getResource()) {
             var p = jedis.pipelined();
             p.del(key);
@@ -44,6 +86,7 @@ public class ProfileCacheService {
                 String json = jsonMapper.writeValueAsString(dto);
                 p.rpush(key, json);
             }
+
             p.expire(key, RedisManager.CHARM_QUEUE_TTL_SEC);
             p.sync();
         } catch (Exception e) {
@@ -51,8 +94,10 @@ public class ProfileCacheService {
         }
     }
 
+    // --------------- empty-cooldown ---------------
     public boolean isEmptyCooldownActive(Long userId) {
         String key = EMPTY_KEY_PREFIX + userId;
+
         try (Jedis jedis = RedisManager.getResource()) {
             return jedis.exists(key);
         }
@@ -60,6 +105,7 @@ public class ProfileCacheService {
 
     public void markEmptyCooldown(Long userId) {
         String key = EMPTY_KEY_PREFIX + userId;
+
         try (Jedis jedis = RedisManager.getResource()) {
             jedis.setex(key, RedisManager.CHARM_EMPTY_TTL_SEC, "1");
         }
@@ -67,6 +113,7 @@ public class ProfileCacheService {
 
     public void clearEmptyCooldown(Long userId) {
         String key = EMPTY_KEY_PREFIX + userId;
+
         try (Jedis jedis = RedisManager.getResource()) {
             jedis.del(key);
         }

--- a/src/ru/andrewb/charm/back/utils/RedisManager.java
+++ b/src/ru/andrewb/charm/back/utils/RedisManager.java
@@ -15,6 +15,8 @@ public class RedisManager {
             Integer.parseInt(Config.getOrDefault("app.redis.charm-queue-ttl-sec", "300"));
     public static final int CHARM_EMPTY_TTL_SEC =
             Integer.parseInt(Config.getOrDefault("app.redis.charm-empty-ttl-sec", "60"));
+    public static final int CHARM_LOCK_TTL_SEC =
+            Integer.parseInt(Config.getOrDefault("app.redis.charm-lock-ttl-sec", "3"));
 
     // pool tuning
     private static final int TIMEOUT_MS = Integer.parseInt(Config.getOrDefault("app.redis.timeout-ms", "2000"));


### PR DESCRIPTION
Что сделано
 - Добавлен per-user refill lock в Redis (SET NX EX) для защиты от гонок при заполнении очереди кандидатов. 
 - EX выставляется на случай если поток возьмет lock и упадет с ошибкой - по истечении заданного времени lock протухнет.
 - Реализован безопасный release lock через Lua (lock удаляется только если token совпадает).
 - При невозможности взять lock - сразу возвращаем Optional.empty() (не дергаем БД/Redis повторно).

Зачем
 - Исключаем ситуацию, при которой несколько потоков видят пустую очередь и все идут в БД.
 - Делаем refill очереди "single-flight" на пользователя и защищаем от лишней нагрузки.