### PR TITLE
 Use bcrypt hashes in seeds and tune DB pool defaults

### DIFF
--- a/resources/application-example.properties
+++ b/resources/application-example.properties
@@ -13,21 +13,34 @@
 #   - JVM:     -Dapp.profile.active=local
 #   - Env:     export APP_PROFILE=local
 #
-# Copy this file to: application-local.properties
-# and adjust values for YOUR machine. Do NOT commit your local file.
+# Copy this file to: application-<profile>.properties
+# and adjust values for YOUR machine. Do NOT commit your <profile> file.
 # ============================================================
-#
-# --- Database ---
+
+# ==================== Required fields =======================
+# Database
 app.datasource.url=jdbc:postgresql://<DB_HOST:PORT>/<DB_NAME>
 app.datasource.username=<DB_USER>
 app.datasource.password=<DB_PASSWORD>
 app.datasource.driver-class-name=org.postgresql.Driver
-#
-# Optional tuning (defaults are fine):
-# app.datasource.fetch-size=100
-# app.datasource.max-rows=1000
-# app.datasource.query-timeout=10
-#
-# --- Files / content storage ---
+# Cache (Redis)
+app.redis.host=<REDIS_HOST>
+app.redis.port=<REDIS_PORT>
+# Files / content storage
 # Absolute path to a local folder where uploaded files should be stored
 app.content.base-path=/absolute/path/to/your/data-dir
+
+# ==================== Optional fields =======================
+# Database
+app.datasource.fetch-size=100
+app.datasource.max-rows=1000
+app.datasource.query-timeout=10
+# Cache (Redis)
+app.redis.charm-queue-ttl-sec=300
+app.redis.charm-empty-ttl-sec=60
+app.redis.charm-lock-ttl-sec=20
+app.redis.timeout-ms=2000
+app.redis.pool.max-total=16
+app.redis.pool.max-idle=16
+app.redis.pool.min-idle=0
+app.redis.pool.test-on-borrow=true

--- a/resources/application.properties
+++ b/resources/application.properties
@@ -8,7 +8,7 @@ app.datasource.driver-class-name=org.postgresql.Driver
 app.datasource.fetch-size=100
 app.datasource.max-rows=1000
 app.datasource.query-timeout=10
-app.datasource.pool.size=5
+app.datasource.pool.size=10
 app.datasource.pool.acquire-timeout-ms=3000
 # --- Cache (Redis)
 app.redis.host=localhost

--- a/src/ru/andrewb/charm/back/sql/seed_bulk_1k.sql
+++ b/src/ru/andrewb/charm/back/sql/seed_bulk_1k.sql
@@ -1,3 +1,8 @@
+"""
+insert 1000 test users with passwords:
+user<id>@charm.ru - password
+"""
+
 WITH params AS (
     SELECT 1000::int AS n
 ),
@@ -8,7 +13,7 @@ base AS (
 INSERT INTO profile (email, password, "name", surname, birthdate, about, gender, status, role)
 SELECT
     'user' || (b.start_id + g.i)::text || '@mail.ru',
-    'pass' || (b.start_id + g.i)::text,
+    '$2a$10$1CmwmzBGXw1nulcCNyXUZ.34Pq5K/QKJJ.wzWpC1Um5YICgZVRZ4a',
     (ARRAY['Ivan','Petr','Andrei','Sergey','Alex','Dmitry','Elena','Olga','Maria','Anna'])[
         1 + floor(random()*10)::int
     ],

--- a/src/ru/andrewb/charm/back/sql/seed_dev.sql
+++ b/src/ru/andrewb/charm/back/sql/seed_dev.sql
@@ -1,11 +1,18 @@
+"""
+insert 3 test users with passwords:
+admin@charm.ru   - qwerty
+ivanov@mail.ru   - 123456
+sidorova@mail.ru - 456789
+"""
+
 TRUNCATE TABLE profile_like;
 TRUNCATE TABLE profile RESTART IDENTITY CASCADE;
 
 INSERT INTO profile (email, password, "name", surname, birthdate, about, gender, status, role)
 VALUES
-    ('admin@charm.ru',   'qwerty', 'Admin',  NULL,         NULL,               NULL,           NULL,     'INACTIVE','ADMIN'),
-    ('ivanov@mail.ru',   '123',    'Ivan',   'Ivanov',     '2001-12-03'::DATE, 'I am QA',      'MALE',   'ACTIVE',  'USER'),
-    ('sidorova@mail.ru', '456',    'Elena',  'Sidorova',   '1999-09-01'::DATE, 'I am Java Dev','FEMALE', 'ACTIVE',  'USER');
+    ('admin@charm.ru',   '$2a$10$lsHPyUkTiS1qKFwWqfGTrePIkDyA/r4TTD6O/bnG.oRNDDDm8aW92', 'Admin',  NULL,       NULL,               NULL,           NULL,     'INACTIVE','ADMIN'),
+    ('ivanov@mail.ru',   '$2a$10$OCJYDgujqIh3NoG4GuCg/.rMsGmYF4SghfLnG3JUEKnmlrLaaFSU2', 'Ivan',   'Ivanov',   '2001-12-03'::DATE, 'I am QA',      'MALE',   'ACTIVE',  'USER'),
+    ('sidorova@mail.ru', '$2a$10$CQX6kKadS86fpJypAb0jOemSdV3LNxhdxMQYSl0ijlOi8DfHjBiF6', 'Elena',  'Sidorova', '1999-09-01'::DATE, 'I am Java Dev','FEMALE', 'ACTIVE',  'USER');
 
 INSERT INTO profile_like (a_profile, b_profile, liked_a, liked_b)
 SELECT LEAST(p1.id, p2.id), GREATEST(p1.id, p2.id), TRUE, TRUE

--- a/src/ru/andrewb/charm/back/utils/ConnectionManager.java
+++ b/src/ru/andrewb/charm/back/utils/ConnectionManager.java
@@ -49,7 +49,7 @@ public class ConnectionManager {
                 config.setUsername(USER);
                 config.setPassword(PASSWORD);
                 config.setMaximumPoolSize(POOL_SIZE);
-                config.setMinimumIdle(5);
+                config.setMinimumIdle(2);
                 config.setConnectionTimeout(10000);
                 config.setIdleTimeout(60000);
                 config.setMaxLifetime(1800000);


### PR DESCRIPTION
Что сделано
- plaintext-пароли заменены на bcrypt-хэши в seed_dev.sql и seed_bulk_1k.sql, добавлены комментарии с тестовыми логинами/паролями.
- Обновлен application-example.properties: добавлен блок Optional fields (DB/Redis параметры).
- Изменены дефолты пула:
  - app.datasource.pool.size в application.properties: 5 -> 10;
  - minimumIdle в ConnectionManager: 5 -> 2.

Зачем
 - Избежать паролей в открытом виде в БД даже в тестовых сид-записях.
 - Улучшить читаемость application-example.properties (быстрее старт/онбординг).
 - Улучшить дефолты пула для дев-режима: меньше простаивающих коннектов (minIdle), но достаточно коннектов под нагрузку (pool size).