### PR TITLE
Redis port optional + relax hikari acquire timeout

### DIFF
--- a/resources/application-example.properties
+++ b/resources/application-example.properties
@@ -25,7 +25,6 @@ app.datasource.password=<DB_PASSWORD>
 app.datasource.driver-class-name=org.postgresql.Driver
 # Cache (Redis)
 app.redis.host=<REDIS_HOST>
-app.redis.port=<REDIS_PORT>
 # Files / content storage
 # Absolute path to a local folder where uploaded files should be stored
 app.content.base-path=/absolute/path/to/your/data-dir
@@ -36,6 +35,7 @@ app.datasource.fetch-size=100
 app.datasource.max-rows=1000
 app.datasource.query-timeout=10
 # Cache (Redis)
+app.redis.port=6379
 app.redis.charm-queue-ttl-sec=300
 app.redis.charm-empty-ttl-sec=60
 app.redis.charm-lock-ttl-sec=20

--- a/src/ru/andrewb/charm/back/bootstrap/SetupCheck.java
+++ b/src/ru/andrewb/charm/back/bootstrap/SetupCheck.java
@@ -27,8 +27,7 @@ public class SetupCheck implements ServletContextListener {
                 "app.datasource.username",
                 "app.datasource.password",
                 "app.content.base-path",
-                "app.redis.host",
-                "app.redis.port"
+                "app.redis.host"
         );
 
         // 2) init pools/clients explicitly

--- a/src/ru/andrewb/charm/back/infra/db/ConnectionManager.java
+++ b/src/ru/andrewb/charm/back/infra/db/ConnectionManager.java
@@ -51,7 +51,7 @@ public class ConnectionManager {
                 config.setPassword(password);
                 config.setMaximumPoolSize(poolSize);
                 config.setMinimumIdle(2);
-                config.setConnectionTimeout(3_000);
+                config.setConnectionTimeout(10_000);
                 config.setIdleTimeout(60_000);
                 config.setMaxLifetime(1_800_000);
 


### PR DESCRIPTION
Что сделано
 - Убрано требование app.redis.port в StartupCheck.
 - Увеличен connectionTimeout в HikariConfig до 10s.

Зачем
 - Оставить возможность не задавать порт для Redis (установится дефолтное значение 6379 из RedisManager).
 - Увеличиваем время ожидание соединения из пула на случай холодного старта, 