### PR TITLE
Add REST endpoints for Charm and Matches

### DIFF
--- a/src/ru/andrewb/charm/back/controller/MatchesController.java
+++ b/src/ru/andrewb/charm/back/controller/MatchesController.java
@@ -41,7 +41,7 @@ public class MatchesController extends HttpServlet {
 
         var items = service.findMatches(user.getId(), limit, offset);
         boolean hasNext = items.size() > f.getPageSize();
-        if (hasNext) items = items.subList(0, f.getPageSize());
+        if (hasNext) items = items.subList(0, pageSize);
 
         boolean hasPrev = f.getPage() > 1;
 

--- a/src/ru/andrewb/charm/back/controller/filter/AuthFilter.java
+++ b/src/ru/andrewb/charm/back/controller/filter/AuthFilter.java
@@ -38,12 +38,13 @@ public class AuthFilter implements Filter {
                 filterChain.doFilter(req, resp);
                 return;
             }
-            // Other rest (only for admin)
+            // Everything else requires login
             if (user == null) {
                 resp.sendError(HttpServletResponse.SC_UNAUTHORIZED);
                 return;
             }
-            if (!isAdmin) {
+            // Profiles list only for admin
+            if (PROFILES_REST_URL.equals(path) && !isAdmin) {
                 resp.sendError(HttpServletResponse.SC_FORBIDDEN);
                 return;
             }

--- a/src/ru/andrewb/charm/back/controller/rest/CharmController.java
+++ b/src/ru/andrewb/charm/back/controller/rest/CharmController.java
@@ -1,0 +1,71 @@
+package ru.andrewb.charm.back.controller.rest;
+
+import com.fasterxml.jackson.databind.DatabindException;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import ru.andrewb.charm.back.dto.CharmDto;
+import ru.andrewb.charm.back.dto.ProfileSimpleDto;
+import ru.andrewb.charm.back.dto.UserDetailsDto;
+import ru.andrewb.charm.back.mapper.JsonMapper;
+import ru.andrewb.charm.back.normalizer.CharmDtoDefaults;
+import ru.andrewb.charm.back.security.AuthUtils;
+import ru.andrewb.charm.back.service.CharmService;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+
+import static ru.andrewb.charm.back.web.Urls.CHARM_REST_URL;
+
+@WebServlet(CHARM_REST_URL)
+public class CharmController extends HttpServlet {
+
+    private final CharmService service = CharmService.getInstance();
+    private final JsonMapper jsonMapper = JsonMapper.getInstance();
+
+    public record NextResponse(ProfileSimpleDto profile) {}
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        UserDetailsDto user = AuthUtils.getUserOrNull(req);
+        if (user == null) {
+            resp.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+            return;
+        }
+
+        var dto = new CharmDto();
+        dto.setFromProfileId(user.getId());
+        CharmDtoDefaults.normalize(dto);
+
+        Optional<ProfileSimpleDto> nextOpt = service.getNext(dto);
+        resp.setContentType("application/json;charset=UTF-8");
+        jsonMapper.writeValue(resp.getWriter(), new NextResponse(nextOpt.orElse(null)));
+    }
+
+    @Override
+    protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        UserDetailsDto user = AuthUtils.getUserOrNull(req);
+        if (user == null) {
+            resp.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+            return;
+        }
+
+        try (BufferedReader reader = req.getReader()) {
+            var dto = jsonMapper.readValue(reader, CharmDto.class);
+            dto.setFromProfileId(user.getId());
+            CharmDtoDefaults.normalize(dto);
+
+            Optional<ProfileSimpleDto> nextOpt = service.getNext(dto);
+            resp.setContentType("application/json;charset=UTF-8");
+            jsonMapper.writeValue(resp.getWriter(), new NextResponse(nextOpt.orElse(null)));
+
+        } catch (DatabindException e) {
+            req.setAttribute("errors", List.of("error.param.invalid"));
+            resp.sendError(HttpServletResponse.SC_BAD_REQUEST);
+        }
+    }
+}

--- a/src/ru/andrewb/charm/back/controller/rest/LoginController.java
+++ b/src/ru/andrewb/charm/back/controller/rest/LoginController.java
@@ -45,10 +45,10 @@ public class LoginController extends HttpServlet {
         } catch (DatabindException e) {
             req.setAttribute("errors", List.of("error.param.invalid"));
             resp.sendError(HttpServletResponse.SC_BAD_REQUEST);
+
         } catch (BadRequestException e) {
             req.setAttribute("errors", List.of(e.getMessage()));
             resp.sendError(HttpServletResponse.SC_BAD_REQUEST);
-
         }
     }
 }

--- a/src/ru/andrewb/charm/back/controller/rest/LogoutController.java
+++ b/src/ru/andrewb/charm/back/controller/rest/LogoutController.java
@@ -1,0 +1,27 @@
+package ru.andrewb.charm.back.controller.rest;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import ru.andrewb.charm.back.dto.UserDetailsDto;
+import ru.andrewb.charm.back.security.AuthUtils;
+
+import java.io.IOException;
+
+import static ru.andrewb.charm.back.web.Urls.LOGOUT_REST_URL;
+
+@Slf4j
+@WebServlet(LOGOUT_REST_URL)
+public class LogoutController extends HttpServlet {
+    @Override
+    protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        UserDetailsDto user = AuthUtils.getUserOrNull(req);
+        if (user != null) {
+            req.getSession(false).invalidate();
+        }
+        resp.setStatus(HttpServletResponse.SC_NO_CONTENT);
+    }
+}

--- a/src/ru/andrewb/charm/back/controller/rest/MatchesController.java
+++ b/src/ru/andrewb/charm/back/controller/rest/MatchesController.java
@@ -1,0 +1,54 @@
+package ru.andrewb.charm.back.controller.rest;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import ru.andrewb.charm.back.dto.ProfileGetDto;
+import ru.andrewb.charm.back.dto.UserDetailsDto;
+import ru.andrewb.charm.back.mapper.JsonMapper;
+import ru.andrewb.charm.back.mapper.RequestToProfileFilterMapper;
+import ru.andrewb.charm.back.normalizer.ProfileFilterDefaults;
+import ru.andrewb.charm.back.security.AuthUtils;
+import ru.andrewb.charm.back.service.ProfileService;
+
+import java.io.IOException;
+import java.util.List;
+
+import static ru.andrewb.charm.back.web.Urls.*;
+
+@WebServlet(MATCHES_REST_URL)
+public class MatchesController extends HttpServlet {
+
+    private final ProfileService service = ProfileService.getInstance();
+    private final RequestToProfileFilterMapper requestToProfileFilterMapper = RequestToProfileFilterMapper.getInstance();
+    private final JsonMapper jsonMapper = JsonMapper.getInstance();
+
+    public record MatchesResponse(List<ProfileGetDto> items, boolean hasNext) {}
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        UserDetailsDto user = AuthUtils.getUserOrNull(req);
+        if (user == null) {
+            resp.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+            return;
+        }
+
+        var f = requestToProfileFilterMapper.map(req);
+        ProfileFilterDefaults.normalize(f);
+
+        int page = Math.max(1, f.getPage());
+        int pageSize = Math.max(1, f.getPageSize());
+        int limit = pageSize + 1;
+        int offset = (page - 1) * pageSize;
+
+        var items = service.findMatches(user.getId(), limit, offset);
+        boolean hasNext = items.size() > f.getPageSize();
+        if (hasNext) items = items.subList(0, pageSize);
+
+        resp.setStatus(HttpServletResponse.SC_OK);
+        resp.setContentType("application/json;charset=UTF-8");
+        jsonMapper.writeValue(resp.getWriter(), new MatchesResponse(items, hasNext));
+    }
+}

--- a/src/ru/andrewb/charm/back/controller/rest/ProfileController.java
+++ b/src/ru/andrewb/charm/back/controller/rest/ProfileController.java
@@ -8,15 +8,12 @@ import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
-import ru.andrewb.charm.back.dto.RegistrationDto;
-import ru.andrewb.charm.back.dto.UserDetailsDto;
+import ru.andrewb.charm.back.dto.ProfileUpdateDto;
 import ru.andrewb.charm.back.mapper.JsonMapper;
-import ru.andrewb.charm.back.mapper.RequestToProfileUpdateDtoMapper;
 import ru.andrewb.charm.back.model.exception.BadRequestException;
-import ru.andrewb.charm.back.model.exception.DuplicateEmailException;
 import ru.andrewb.charm.back.model.exception.NotFoundException;
+import ru.andrewb.charm.back.security.ProfileAccess;
 import ru.andrewb.charm.back.service.ProfileService;
-import ru.andrewb.charm.back.web.RequestParamUtils;
 import ru.andrewb.charm.back.validator.ProfileUpdateValidator;
 import ru.andrewb.charm.back.validator.RegistrationValidator;
 
@@ -32,25 +29,24 @@ import static ru.andrewb.charm.back.web.Urls.PROFILE_REST_URL;
 public class ProfileController extends HttpServlet {
 
     private final ProfileService service = ProfileService.getInstance();
-
     private final ProfileUpdateValidator profileUpdateValidator = ProfileUpdateValidator.getInstance();
     private final RegistrationValidator registrationValidator = RegistrationValidator.getInstance();
-    private final RequestToProfileUpdateDtoMapper requestToProfileUpdateDtoMapper = RequestToProfileUpdateDtoMapper.getInstance();
     private final JsonMapper jsonMapper = JsonMapper.getInstance();
 
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
         try {
-            long id = RequestParamUtils.requirePositiveLong(req, "id");
+            var authCtx = ProfileAccess.resolveOrSendRest(req, resp);
+            if (authCtx == null) return;
 
-            var dtoOpt = service.findById(id);
-            if (dtoOpt.isPresent()) {
-                resp.setContentType("application/json;charset=UTF-8");
-                jsonMapper.writeValue(resp.getWriter(), dtoOpt.get());
-                return;
-            }
+            long id = authCtx.targetId();
 
-            req.setAttribute("errors", List.of("error.profile.not-found"));
+            var dto = service.findByIdOrThrow(id);
+            resp.setContentType("application/json;charset=UTF-8");
+            jsonMapper.writeValue(resp.getWriter(), dto);
+
+        } catch (NotFoundException e) {
+            req.setAttribute("errors", List.of(e.getMessage()));
             resp.sendError(HttpServletResponse.SC_NOT_FOUND);
 
         } catch (DatabindException e) {
@@ -64,43 +60,13 @@ public class ProfileController extends HttpServlet {
     }
 
     @Override
-    protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws IOException {
-        try (BufferedReader r = req.getReader()) {
-            var dto = jsonMapper.readValue(r, RegistrationDto.class);
-
-            var vr = registrationValidator.validate(dto);
-            if (vr.isNotValid()) {
-                req.setAttribute("errors", vr.getErrors());
-                resp.sendError(HttpServletResponse.SC_BAD_REQUEST);
-                return;
-            }
-
-            Long id = service.save(dto);
-            resp.setStatus(HttpServletResponse.SC_CREATED);
-            resp.setHeader("Location",
-                    req.getContextPath() + PROFILE_REST_URL + "?id=" + id);
-            resp.setContentType("application/json;charset=UTF-8");
-            resp.getWriter().write("{\"id\":" + id + "}");
-
-        } catch (DuplicateEmailException e) {
-            req.setAttribute("errors", List.of(e.getMessage()));
-            resp.sendError(HttpServletResponse.SC_CONFLICT);
-
-        } catch (DatabindException e) {
-            req.setAttribute("errors", List.of("error.param.invalid"));
-            resp.sendError(HttpServletResponse.SC_BAD_REQUEST);
-
-        } catch (BadRequestException e) {
-            req.setAttribute("errors", List.of(e.getMessage()));
-            resp.sendError(HttpServletResponse.SC_BAD_REQUEST);
-        }
-    }
-
-    @Override
     protected void doPut(HttpServletRequest req, HttpServletResponse resp) throws IOException {
-        try {
-            long id = RequestParamUtils.requirePositiveLong(req, "id");
-            var dto = requestToProfileUpdateDtoMapper.map(req);
+        try (BufferedReader reader = req.getReader()) {
+            var authCtx = ProfileAccess.resolveOrSendRest(req, resp);
+            if (authCtx == null) return;
+
+            long id = authCtx.targetId();
+            var dto = jsonMapper.readValue(reader, ProfileUpdateDto.class);
 
             var vr = profileUpdateValidator.validate(dto);
             if (vr.isNotValid()) {
@@ -130,7 +96,10 @@ public class ProfileController extends HttpServlet {
     @Override
     protected void doDelete(HttpServletRequest req, HttpServletResponse resp) throws IOException {
         try {
-            long id = RequestParamUtils.requirePositiveLong(req, "id");
+            var authCtx = ProfileAccess.resolveOrSendRest(req, resp);
+            if (authCtx == null) return;
+
+            long id = authCtx.targetId();
 
             boolean deleted = service.delete(id);
             if (!deleted) {
@@ -139,9 +108,8 @@ public class ProfileController extends HttpServlet {
                 return;
             }
 
-            var sessionUser = (UserDetailsDto) req.getSession().getAttribute("userDetails");
-            if (sessionUser != null && sessionUser.getId() != null && sessionUser.getId().equals(id)) {
-                req.getSession().invalidate();
+            if (authCtx.user().getId().equals(id)) {
+                req.getSession(false).invalidate();
             }
             resp.setStatus(HttpServletResponse.SC_NO_CONTENT);
 

--- a/src/ru/andrewb/charm/back/controller/rest/ProfilesController.java
+++ b/src/ru/andrewb/charm/back/controller/rest/ProfilesController.java
@@ -27,16 +27,10 @@ public class ProfilesController extends HttpServlet {
 
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
-        try {
-            ProfileFilter f = requestToProfileFilterMapper.map(req);
-            ProfileFilterDefaults.normalize(f);
+        ProfileFilter f = requestToProfileFilterMapper.map(req);
+        ProfileFilterDefaults.normalize(f);
 
-            resp.setContentType("application/json;charset=UTF-8");
-            jsonMapper.writeValue(resp.getWriter(), service.findAll(f));
-
-        } catch (DatabindException e) {
-            req.setAttribute("errors", List.of("error.param.invalid"));
-            resp.sendError(HttpServletResponse.SC_BAD_REQUEST);
-        }
+        resp.setContentType("application/json;charset=UTF-8");
+        jsonMapper.writeValue(resp.getWriter(), service.findAll(f));
     }
 }

--- a/src/ru/andrewb/charm/back/controller/rest/RegistrationController.java
+++ b/src/ru/andrewb/charm/back/controller/rest/RegistrationController.java
@@ -1,0 +1,60 @@
+package ru.andrewb.charm.back.controller.rest;
+
+import com.fasterxml.jackson.databind.DatabindException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import ru.andrewb.charm.back.dto.RegistrationDto;
+import ru.andrewb.charm.back.mapper.JsonMapper;
+import ru.andrewb.charm.back.model.exception.BadRequestException;
+import ru.andrewb.charm.back.model.exception.DuplicateEmailException;
+import ru.andrewb.charm.back.service.ProfileService;
+import ru.andrewb.charm.back.validator.RegistrationValidator;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import static ru.andrewb.charm.back.web.Urls.*;
+
+@WebServlet(REGISTRATION_REST_URL)
+public class RegistrationController extends HttpServlet {
+
+    private final ProfileService service = ProfileService.getInstance();
+    private final RegistrationValidator registrationValidator = RegistrationValidator.getInstance();
+    private final JsonMapper jsonMapper = JsonMapper.getInstance();
+
+    @Override
+    protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+        try (BufferedReader reader = req.getReader()) {
+            var dto = jsonMapper.readValue(reader, RegistrationDto.class);
+
+            var vr = registrationValidator.validate(dto);
+            if (vr.isNotValid()) {
+                req.setAttribute("errors", vr.getErrors());
+                resp.sendError(HttpServletResponse.SC_BAD_REQUEST);
+                return;
+            }
+
+            Long id = service.save(dto);
+            resp.setStatus(HttpServletResponse.SC_CREATED);
+            resp.setHeader("Location", req.getContextPath() + PROFILE_REST_URL + "?id=" + id);
+            resp.setContentType("application/json;charset=UTF-8");
+            jsonMapper.writeValue(resp.getWriter(), Map.of("id", id));
+
+        } catch (DuplicateEmailException e) {
+            req.setAttribute("errors", List.of(e.getMessage()));
+            resp.sendError(HttpServletResponse.SC_CONFLICT);
+
+        } catch (DatabindException e) {
+            req.setAttribute("errors", List.of("error.param.invalid"));
+            resp.sendError(HttpServletResponse.SC_BAD_REQUEST);
+
+        } catch (BadRequestException e) {
+            req.setAttribute("errors", List.of(e.getMessage()));
+            resp.sendError(HttpServletResponse.SC_BAD_REQUEST);
+        }
+    }
+}

--- a/src/ru/andrewb/charm/back/security/ProfileAccess.java
+++ b/src/ru/andrewb/charm/back/security/ProfileAccess.java
@@ -36,4 +36,26 @@ public class ProfileAccess {
 
         return new Ctx(user, id, isAdmin);
     }
+
+    public static Ctx resolveOrSendRest(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+        UserDetailsDto user = AuthUtils.getUserOrNull(req);
+        if (user == null) {
+            resp.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+            return null;
+        }
+
+        String idParam = req.getParameter("id");
+        long id = (idParam == null || idParam.isBlank())
+                ? user.getId()
+                : RequestParamUtils.requirePositiveLong(req, "id");
+
+        boolean isAdmin = (user.getRole() == Role.ADMIN);
+        if (!isAdmin && id != user.getId()) {
+            resp.sendError(HttpServletResponse.SC_FORBIDDEN);
+            return null;
+        }
+
+        return new Ctx(user, id, isAdmin);
+    }
+
 }

--- a/src/ru/andrewb/charm/back/security/SecurityRules.java
+++ b/src/ru/andrewb/charm/back/security/SecurityRules.java
@@ -18,7 +18,7 @@ public class SecurityRules {
     );
 
     public static final Set<String> PUBLIC_REST = Set.of(
-            LOGIN_REST_URL
+            LOGIN_REST_URL, LOGOUT_REST_URL, REGISTRATION_REST_URL
     );
 
     public static boolean isRest(String path) {

--- a/src/ru/andrewb/charm/back/web/Urls.java
+++ b/src/ru/andrewb/charm/back/web/Urls.java
@@ -21,6 +21,10 @@ public class Urls {
 
     public static final String REST_PREFIX = "/api/v1";
     public static final String LOGIN_REST_URL = REST_PREFIX + LOGIN_URL;
+    public static final String LOGOUT_REST_URL = REST_PREFIX + LOGOUT_URL;
+    public static final String REGISTRATION_REST_URL = REST_PREFIX + REGISTRATION_URL;
     public static final String PROFILE_REST_URL = REST_PREFIX + PROFILE_URL;
     public static final String PROFILES_REST_URL = REST_PREFIX + PROFILES_URL;
+    public static final String CHARM_REST_URL = REST_PREFIX + CHARM_URL;
+    public static final String MATCHES_REST_URL = REST_PREFIX + MATCHES_URL;
 }


### PR DESCRIPTION
Что сделано
 - Добавлены REST-контроллеры:
   - POST /api/v1/logout (logout)
   - POST /api/v1/registration (регистрация, ответ { "id": <newId> })
   - GET /api/v1/charm (получение следующей карточки; ответ обёртка { "profile": <dto|null> })
   - POST /api/v1/charm принимает {"toProfileId":123,"action":"LIKE|DISLIKE|SKIP"} и возвращает следующую карточку в том же формате что и GET
   - GET /api/v1/matches (пагинация через параметры запроса; ответ обёртка { "items": [...], "hasNext": true/false })
 - Обновлены security rules:
   - PUBLIC_REST расширен (login/logout/registration публичные)
   - Остальные REST доступны любому авторизованному пользователю
   - GET /api/v1/profiles по-прежнему только для ADMIN
 - Добавлены новые REST URL-константы в Urls
 - Вынесена общая логика доступа к профилю в ProfileAccess.resolveOrSendRest

Зачем
 - Добавлены REST-эндпоинты для базовых действий клиента, чтобы он мог работать без JSP.
 - Ответы REST-эндпоинтов приведены к общему формату, чтобы их было проще обрабатывать.
 - Большинство REST-ручек теперь доступны любому залогиненному пользователю, андминским остается только просмотр списка профилей /api/v1/profiles.