### PR TITLE
Add unit tests and refactor services for DI

### DIFF
--- a/back/pom.xml
+++ b/back/pom.xml
@@ -80,8 +80,19 @@
 
         <!--test-->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 
@@ -111,7 +122,6 @@
     </profiles>
 
     <build>
-        <finalName>charm-back</finalName>
         <plugins>
             <plugin>
                 <groupId>org.codehaus.cargo</groupId>
@@ -120,6 +130,10 @@
             <plugin>
                 <groupId>ru.andrewb.charm</groupId>
                 <artifactId>linecount-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/back/src/main/java/ru/andrewb/charm/back/bootstrap/AppComponents.java
+++ b/back/src/main/java/ru/andrewb/charm/back/bootstrap/AppComponents.java
@@ -1,0 +1,42 @@
+package ru.andrewb.charm.back.bootstrap;
+
+import ru.andrewb.charm.back.config.Config;
+import ru.andrewb.charm.back.dao.ProfileDao;
+import ru.andrewb.charm.back.dao.ProfileLikeDao;
+import ru.andrewb.charm.back.mapper.ProfileGetDtoToPdfMapper;
+import ru.andrewb.charm.back.mapper.ProfileToProfileGetDtoMapper;
+import ru.andrewb.charm.back.mapper.ProfileToUserDetailsDtoMapper;
+import ru.andrewb.charm.back.mapper.ProfileUpdateDtoToProfileMapper;
+import ru.andrewb.charm.back.service.CharmService;
+import ru.andrewb.charm.back.service.ContentService;
+import ru.andrewb.charm.back.service.ProfileCacheService;
+import ru.andrewb.charm.back.service.ProfileService;
+
+import java.nio.file.Path;
+
+public final class AppComponents {
+
+    public static final ContentService CONTENT_SERVICE = new ContentService(
+            Path.of(Config.required("app.content.base-path"))
+    );
+
+    public static final ProfileGetDtoToPdfMapper PROFILE_GET_DTO_TO_PDF_MAPPER =
+            new ProfileGetDtoToPdfMapper(CONTENT_SERVICE);
+
+    public static final ProfileService PROFILE_SERVICE = new ProfileService(
+            ProfileDao.getInstance(),
+            CONTENT_SERVICE,
+            ProfileToProfileGetDtoMapper.getInstance(),
+            ProfileUpdateDtoToProfileMapper.getInstance(),
+            ProfileToUserDetailsDtoMapper.getInstance()
+    );
+
+    public static final CharmService CHARM_SERVICE = new CharmService(
+            ProfileDao.getInstance(),
+            ProfileLikeDao.getInstance(),
+            ProfileCacheService.getInstance()
+    );
+
+    private AppComponents() {
+    }
+}

--- a/back/src/main/java/ru/andrewb/charm/back/bootstrap/SetupCheck.java
+++ b/back/src/main/java/ru/andrewb/charm/back/bootstrap/SetupCheck.java
@@ -9,7 +9,6 @@ import ru.andrewb.charm.back.dao.ProfileDao;
 import ru.andrewb.charm.back.dao.ProfileLikeDao;
 import ru.andrewb.charm.back.infra.cache.RedisManager;
 import ru.andrewb.charm.back.infra.db.ConnectionManager;
-import ru.andrewb.charm.back.service.ContentService;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -37,7 +36,6 @@ public class SetupCheck implements ServletContextListener {
         RedisManager.initOrThrow();
 
         // 3) init singletons
-        ContentService.getInstance();
         ProfileDao.getInstance();
         ProfileLikeDao.getInstance();
 

--- a/back/src/main/java/ru/andrewb/charm/back/controller/CharmController.java
+++ b/back/src/main/java/ru/andrewb/charm/back/controller/CharmController.java
@@ -5,6 +5,7 @@ import jakarta.servlet.annotation.WebServlet;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import ru.andrewb.charm.back.bootstrap.AppComponents;
 import ru.andrewb.charm.back.dto.ProfileSimpleDto;
 import ru.andrewb.charm.back.dto.UserDetailsDto;
 import ru.andrewb.charm.back.mapper.RequestToCharmDtoMapper;
@@ -21,7 +22,7 @@ import static ru.andrewb.charm.back.web.Views.getJspPath;
 @WebServlet(CHARM_URL)
 public class CharmController extends HttpServlet {
 
-    private final CharmService service = CharmService.getInstance();
+    private final CharmService service = AppComponents.CHARM_SERVICE;
 
     private final RequestToCharmDtoMapper requestToCharmDtoMapper = RequestToCharmDtoMapper.getInstance();
 

--- a/back/src/main/java/ru/andrewb/charm/back/controller/ContentController.java
+++ b/back/src/main/java/ru/andrewb/charm/back/controller/ContentController.java
@@ -4,6 +4,7 @@ import jakarta.servlet.annotation.WebServlet;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import ru.andrewb.charm.back.bootstrap.AppComponents;
 import ru.andrewb.charm.back.dto.UserDetailsDto;
 import ru.andrewb.charm.back.model.Role;
 import ru.andrewb.charm.back.model.exception.BadRequestException;
@@ -19,7 +20,7 @@ import static ru.andrewb.charm.back.web.Urls.LOGIN_URL;
 @WebServlet(CONTENT_URL + "/*")
 public class ContentController extends HttpServlet {
 
-    public static final ContentService contentService = ContentService.getInstance();
+    public static final ContentService contentService = AppComponents.CONTENT_SERVICE;
 
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {

--- a/back/src/main/java/ru/andrewb/charm/back/controller/EmailChangeController.java
+++ b/back/src/main/java/ru/andrewb/charm/back/controller/EmailChangeController.java
@@ -5,6 +5,7 @@ import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
+import ru.andrewb.charm.back.bootstrap.AppComponents;
 import ru.andrewb.charm.back.service.ProfileService;
 import ru.andrewb.charm.back.dto.UserDetailsDto;
 import ru.andrewb.charm.back.mapper.RequestToEmailChangeDtoMapper;
@@ -26,7 +27,7 @@ import static ru.andrewb.charm.back.web.Urls.*;
 @WebServlet(EMAIL_URL)
 public class EmailChangeController extends HttpServlet {
 
-    private final ProfileService service = ProfileService.getInstance();
+    private final ProfileService service = AppComponents.PROFILE_SERVICE;
     private final EmailChangeValidator emailChangeValidator = EmailChangeValidator.getInstance();
     private final RequestToEmailChangeDtoMapper emailChangeDtoMapper = RequestToEmailChangeDtoMapper.getInstance();
 

--- a/back/src/main/java/ru/andrewb/charm/back/controller/LoginController.java
+++ b/back/src/main/java/ru/andrewb/charm/back/controller/LoginController.java
@@ -6,6 +6,7 @@ import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
+import ru.andrewb.charm.back.bootstrap.AppComponents;
 import ru.andrewb.charm.back.mapper.RequestToLoginDtoMapper;
 import ru.andrewb.charm.back.service.ProfileService;
 import ru.andrewb.charm.back.dto.UserDetailsDto;
@@ -24,7 +25,7 @@ import static ru.andrewb.charm.back.web.Views.getJspPath;
 @WebServlet(LOGIN_URL)
 public class LoginController extends HttpServlet {
 
-    private final ProfileService service = ProfileService.getInstance();
+    private final ProfileService service = AppComponents.PROFILE_SERVICE;
     private final LoginValidator loginValidator = LoginValidator.getInstance();
     private final RequestToLoginDtoMapper requestToLoginDtoMapper = RequestToLoginDtoMapper.getInstance();
 

--- a/back/src/main/java/ru/andrewb/charm/back/controller/MatchesController.java
+++ b/back/src/main/java/ru/andrewb/charm/back/controller/MatchesController.java
@@ -5,6 +5,7 @@ import jakarta.servlet.annotation.WebServlet;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import ru.andrewb.charm.back.bootstrap.AppComponents;
 import ru.andrewb.charm.back.service.ProfileService;
 import ru.andrewb.charm.back.dto.UserDetailsDto;
 import ru.andrewb.charm.back.mapper.RequestToProfileFilterMapper;
@@ -20,7 +21,7 @@ import static ru.andrewb.charm.back.web.Views.getJspPath;
 @WebServlet(MATCHES_URL)
 public class MatchesController extends HttpServlet {
 
-    private final ProfileService service = ProfileService.getInstance();
+    private final ProfileService service = AppComponents.PROFILE_SERVICE;
     private final RequestToProfileFilterMapper requestToProfileFilterMapper = RequestToProfileFilterMapper.getInstance();
 
     @Override

--- a/back/src/main/java/ru/andrewb/charm/back/controller/PasswordChangeController.java
+++ b/back/src/main/java/ru/andrewb/charm/back/controller/PasswordChangeController.java
@@ -5,6 +5,7 @@ import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
+import ru.andrewb.charm.back.bootstrap.AppComponents;
 import ru.andrewb.charm.back.service.ProfileService;
 import ru.andrewb.charm.back.dto.UserDetailsDto;
 import ru.andrewb.charm.back.mapper.RequestToPasswordChangeDtoMapper;
@@ -23,7 +24,7 @@ import static ru.andrewb.charm.back.web.Urls.*;
 @WebServlet(PASSWORD_URL)
 public class PasswordChangeController extends HttpServlet {
 
-    private final ProfileService service = ProfileService.getInstance();
+    private final ProfileService service = AppComponents.PROFILE_SERVICE;
     private final PasswordChangeValidator passwordChangeValidator = PasswordChangeValidator.getInstance();
     private final RequestToPasswordChangeDtoMapper passwordChangeDtoMapper = RequestToPasswordChangeDtoMapper.getInstance();
 

--- a/back/src/main/java/ru/andrewb/charm/back/controller/ProfileController.java
+++ b/back/src/main/java/ru/andrewb/charm/back/controller/ProfileController.java
@@ -10,6 +10,7 @@ import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
+import ru.andrewb.charm.back.bootstrap.AppComponents;
 import ru.andrewb.charm.back.model.exception.OptimisticLockException;
 import ru.andrewb.charm.back.model.exception.StorageException;
 import ru.andrewb.charm.back.security.AuthUtils;
@@ -33,10 +34,10 @@ import static ru.andrewb.charm.back.web.Views.getJspPath;
 @WebServlet(PROFILE_URL + "/*")
 public class ProfileController extends HttpServlet {
 
-    private final ProfileService service = ProfileService.getInstance();
+    private final ProfileService service = AppComponents.PROFILE_SERVICE;
     private final ProfileUpdateValidator profileUpdateValidator = ProfileUpdateValidator.getInstance();
     private final RequestToProfileUpdateDtoMapper requestToProfileUpdateDtoMapper = RequestToProfileUpdateDtoMapper.getInstance();
-    private final ProfileGetDtoToPdfMapper profileGetDtoToPdfMapper = ProfileGetDtoToPdfMapper.getInstance();
+    private final ProfileGetDtoToPdfMapper profileGetDtoToPdfMapper = AppComponents.PROFILE_GET_DTO_TO_PDF_MAPPER;
 
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {

--- a/back/src/main/java/ru/andrewb/charm/back/controller/ProfilesController.java
+++ b/back/src/main/java/ru/andrewb/charm/back/controller/ProfilesController.java
@@ -6,6 +6,7 @@ import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
+import ru.andrewb.charm.back.bootstrap.AppComponents;
 import ru.andrewb.charm.back.security.AuthUtils;
 import ru.andrewb.charm.back.service.ProfileService;
 import ru.andrewb.charm.back.dto.ProfileFilter;
@@ -27,7 +28,7 @@ import static ru.andrewb.charm.back.web.Views.getJspPath;
 @WebServlet(PROFILES_URL)
 public class ProfilesController extends HttpServlet {
 
-    private final ProfileService service = ProfileService.getInstance();
+    private final ProfileService service = AppComponents.PROFILE_SERVICE;
     private final RequestToProfileFilterMapper requestToProfileFilterMapper = RequestToProfileFilterMapper.getInstance();
     private final RequestToProfileUpdateStatusDtoMapper requestToProfileUpdateStatusMapper =
             RequestToProfileUpdateStatusDtoMapper.getInstance();

--- a/back/src/main/java/ru/andrewb/charm/back/controller/RegistrationController.java
+++ b/back/src/main/java/ru/andrewb/charm/back/controller/RegistrationController.java
@@ -6,6 +6,7 @@ import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
+import ru.andrewb.charm.back.bootstrap.AppComponents;
 import ru.andrewb.charm.back.service.ProfileService;
 import ru.andrewb.charm.back.mapper.RequestToRegistrationDtoMapper;
 import ru.andrewb.charm.back.model.exception.BadRequestException;
@@ -23,7 +24,7 @@ import static ru.andrewb.charm.back.web.Views.getJspPath;
 @WebServlet(REGISTRATION_URL)
 public class RegistrationController extends HttpServlet {
 
-    private final ProfileService service = ProfileService.getInstance();
+    private final ProfileService service = AppComponents.PROFILE_SERVICE;
     private final RegistrationValidator registrationValidator = RegistrationValidator.getInstance();
     private final RequestToRegistrationDtoMapper requestToRegistrationDtoMapper = RequestToRegistrationDtoMapper.getInstance();
 

--- a/back/src/main/java/ru/andrewb/charm/back/controller/SettingsController.java
+++ b/back/src/main/java/ru/andrewb/charm/back/controller/SettingsController.java
@@ -5,6 +5,7 @@ import jakarta.servlet.annotation.WebServlet;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import ru.andrewb.charm.back.bootstrap.AppComponents;
 import ru.andrewb.charm.back.service.ProfileService;
 import ru.andrewb.charm.back.dto.UserDetailsDto;
 import ru.andrewb.charm.back.model.exception.NotFoundException;
@@ -20,7 +21,7 @@ import static ru.andrewb.charm.back.web.Views.getJspPath;
 @WebServlet(SETTINGS_URL)
 public class SettingsController extends HttpServlet {
 
-    private final ProfileService service = ProfileService.getInstance();
+    private final ProfileService service = AppComponents.PROFILE_SERVICE;
 
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {

--- a/back/src/main/java/ru/andrewb/charm/back/controller/rest/CharmController.java
+++ b/back/src/main/java/ru/andrewb/charm/back/controller/rest/CharmController.java
@@ -6,6 +6,7 @@ import jakarta.servlet.annotation.WebServlet;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import ru.andrewb.charm.back.bootstrap.AppComponents;
 import ru.andrewb.charm.back.dto.CharmDto;
 import ru.andrewb.charm.back.dto.ProfileSimpleDto;
 import ru.andrewb.charm.back.dto.UserDetailsDto;
@@ -24,7 +25,7 @@ import static ru.andrewb.charm.back.web.Urls.CHARM_REST_URL;
 @WebServlet(CHARM_REST_URL)
 public class CharmController extends HttpServlet {
 
-    private final CharmService service = CharmService.getInstance();
+    private final CharmService service = AppComponents.CHARM_SERVICE;
     private final JsonMapper jsonMapper = JsonMapper.getInstance();
 
     public record NextResponse(ProfileSimpleDto profile) {}

--- a/back/src/main/java/ru/andrewb/charm/back/controller/rest/LoginController.java
+++ b/back/src/main/java/ru/andrewb/charm/back/controller/rest/LoginController.java
@@ -6,6 +6,7 @@ import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
+import ru.andrewb.charm.back.bootstrap.AppComponents;
 import ru.andrewb.charm.back.service.ProfileService;
 import ru.andrewb.charm.back.dto.LoginDto;
 import ru.andrewb.charm.back.mapper.JsonMapper;
@@ -22,7 +23,7 @@ import static ru.andrewb.charm.back.web.Urls.LOGIN_REST_URL;
 @WebServlet(LOGIN_REST_URL)
 public class LoginController extends HttpServlet {
 
-    private final ProfileService service = ProfileService.getInstance();
+    private final ProfileService service = AppComponents.PROFILE_SERVICE;
     private final LoginValidator loginValidator = LoginValidator.getInstance();
     private final JsonMapper jsonMapper = JsonMapper.getInstance();
 

--- a/back/src/main/java/ru/andrewb/charm/back/controller/rest/MatchesController.java
+++ b/back/src/main/java/ru/andrewb/charm/back/controller/rest/MatchesController.java
@@ -5,6 +5,7 @@ import jakarta.servlet.annotation.WebServlet;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import ru.andrewb.charm.back.bootstrap.AppComponents;
 import ru.andrewb.charm.back.service.ProfileService;
 import ru.andrewb.charm.back.dto.ProfileGetDto;
 import ru.andrewb.charm.back.dto.UserDetailsDto;
@@ -21,7 +22,7 @@ import static ru.andrewb.charm.back.web.Urls.MATCHES_REST_URL;
 @WebServlet(MATCHES_REST_URL)
 public class MatchesController extends HttpServlet {
 
-    private final ProfileService service = ProfileService.getInstance();
+    private final ProfileService service = AppComponents.PROFILE_SERVICE;
     private final RequestToProfileFilterMapper requestToProfileFilterMapper = RequestToProfileFilterMapper.getInstance();
     private final JsonMapper jsonMapper = JsonMapper.getInstance();
 

--- a/back/src/main/java/ru/andrewb/charm/back/controller/rest/ProfileController.java
+++ b/back/src/main/java/ru/andrewb/charm/back/controller/rest/ProfileController.java
@@ -8,6 +8,7 @@ import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
+import ru.andrewb.charm.back.bootstrap.AppComponents;
 import ru.andrewb.charm.back.dto.EmailChangeDto;
 import ru.andrewb.charm.back.dto.PasswordChangeDto;
 import ru.andrewb.charm.back.model.exception.*;
@@ -30,7 +31,7 @@ import static ru.andrewb.charm.back.web.Urls.PROFILE_REST_URL;
 @WebServlet(PROFILE_REST_URL + "/*")
 public class ProfileController extends HttpServlet {
 
-    private final ProfileService service = ProfileService.getInstance();
+    private final ProfileService service = AppComponents.PROFILE_SERVICE;
 
     private final ProfileUpdateValidator profileUpdateValidator = ProfileUpdateValidator.getInstance();
     private final EmailChangeValidator emailChangeValidator = EmailChangeValidator.getInstance();

--- a/back/src/main/java/ru/andrewb/charm/back/controller/rest/ProfilesController.java
+++ b/back/src/main/java/ru/andrewb/charm/back/controller/rest/ProfilesController.java
@@ -5,6 +5,7 @@ import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
+import ru.andrewb.charm.back.bootstrap.AppComponents;
 import ru.andrewb.charm.back.security.AuthUtils;
 import ru.andrewb.charm.back.service.ProfileService;
 import ru.andrewb.charm.back.dto.ProfileFilter;
@@ -20,7 +21,7 @@ import static ru.andrewb.charm.back.web.Urls.PROFILES_REST_URL;
 @WebServlet(PROFILES_REST_URL)
 public class ProfilesController extends HttpServlet {
 
-    private final ProfileService service = ProfileService.getInstance();
+    private final ProfileService service = AppComponents.PROFILE_SERVICE;
     private final RequestToProfileFilterMapper requestToProfileFilterMapper = RequestToProfileFilterMapper.getInstance();
     private final JsonMapper jsonMapper = JsonMapper.getInstance();
 

--- a/back/src/main/java/ru/andrewb/charm/back/controller/rest/RegistrationController.java
+++ b/back/src/main/java/ru/andrewb/charm/back/controller/rest/RegistrationController.java
@@ -5,6 +5,7 @@ import jakarta.servlet.annotation.WebServlet;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import ru.andrewb.charm.back.bootstrap.AppComponents;
 import ru.andrewb.charm.back.service.ProfileService;
 import ru.andrewb.charm.back.dto.RegistrationDto;
 import ru.andrewb.charm.back.mapper.JsonMapper;
@@ -23,7 +24,7 @@ import static ru.andrewb.charm.back.web.Urls.REGISTRATION_REST_URL;
 @WebServlet(REGISTRATION_REST_URL)
 public class RegistrationController extends HttpServlet {
 
-    private final ProfileService service = ProfileService.getInstance();
+    private final ProfileService service = AppComponents.PROFILE_SERVICE;
     private final RegistrationValidator registrationValidator = RegistrationValidator.getInstance();
     private final JsonMapper jsonMapper = JsonMapper.getInstance();
 

--- a/back/src/main/java/ru/andrewb/charm/back/mapper/ProfileGetDtoToPdfMapper.java
+++ b/back/src/main/java/ru/andrewb/charm/back/mapper/ProfileGetDtoToPdfMapper.java
@@ -6,8 +6,6 @@ import com.itextpdf.text.Image;
 import com.itextpdf.text.Rectangle;
 import com.itextpdf.text.pdf.PdfPCell;
 import com.itextpdf.text.pdf.PdfPTable;
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
 import ru.andrewb.charm.back.dto.ProfileGetDto;
 import ru.andrewb.charm.back.model.exception.PdfBuildException;
 import ru.andrewb.charm.back.service.ContentService;
@@ -16,13 +14,12 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class ProfileGetDtoToPdfMapper implements Mapper<ProfileGetDto, Document> {
 
-    private static final ProfileGetDtoToPdfMapper INSTANCE = new ProfileGetDtoToPdfMapper();
+    private final ContentService contentService;
 
-    public static ProfileGetDtoToPdfMapper getInstance() {
-        return INSTANCE;
+    public ProfileGetDtoToPdfMapper(ContentService contentService) {
+        this.contentService = contentService;
     }
 
     @Override
@@ -63,7 +60,7 @@ public class ProfileGetDtoToPdfMapper implements Mapper<ProfileGetDto, Document>
 
             table.addCell("Photo");
             if (dto.getPhoto() != null && !dto.getPhoto().isBlank()) {
-                Path imgPath = ContentService.getInstance()
+                Path imgPath = contentService
                         .resolve("profile", String.valueOf(dto.getId()), dto.getPhoto());
                 if (Files.exists(imgPath)) {
                     Image img = Image.getInstance(imgPath.toAbsolutePath().toString());

--- a/back/src/main/java/ru/andrewb/charm/back/service/CharmService.java
+++ b/back/src/main/java/ru/andrewb/charm/back/service/CharmService.java
@@ -48,7 +48,7 @@ public class CharmService {
         // Try to acquire per-user refill lock
         String token = profileCacheService.tryAcquireLock(fromId);
         if (token == null) {
-            // Someone already refills thr queue now -> don't spam redis/db
+            // Someone already refills the queue now -> don't spam redis/db
             return Optional.empty();
         }
 

--- a/back/src/main/java/ru/andrewb/charm/back/service/CharmService.java
+++ b/back/src/main/java/ru/andrewb/charm/back/service/CharmService.java
@@ -1,7 +1,5 @@
 package ru.andrewb.charm.back.service;
 
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
 import ru.andrewb.charm.back.dao.ProfileDao;
 import ru.andrewb.charm.back.dao.ProfileLikeDao;
 import ru.andrewb.charm.back.dto.Action;
@@ -11,17 +9,20 @@ import ru.andrewb.charm.back.dto.ProfileSimpleDto;
 import java.util.Optional;
 import java.util.Queue;
 
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class CharmService {
 
-    private static final CharmService INSTANCE = new CharmService();
+    private final ProfileDao profileDao;
+    private final ProfileLikeDao profileLikeDao;
+    private final ProfileCacheService profileCacheService;
 
-    private final ProfileDao profileDao = ProfileDao.getInstance();
-    private final ProfileLikeDao profileLikeDao = ProfileLikeDao.getInstance();
-    private final ProfileCacheService profileCacheService = ProfileCacheService.getInstance();
-
-    public static CharmService getInstance() {
-        return INSTANCE;
+    public CharmService(
+            ProfileDao profileDao,
+            ProfileLikeDao profileLikeDao,
+            ProfileCacheService profileCacheService
+    ) {
+        this.profileDao = profileDao;
+        this.profileLikeDao = profileLikeDao;
+        this.profileCacheService = profileCacheService;
     }
 
     public Optional<ProfileSimpleDto> getNext(CharmDto dto) {

--- a/back/src/main/java/ru/andrewb/charm/back/service/ContentService.java
+++ b/back/src/main/java/ru/andrewb/charm/back/service/ContentService.java
@@ -1,9 +1,6 @@
 package ru.andrewb.charm.back.service;
 
 import jakarta.servlet.ServletOutputStream;
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
-import ru.andrewb.charm.back.config.Config;
 import ru.andrewb.charm.back.model.exception.BadRequestException;
 import ru.andrewb.charm.back.model.exception.NotFoundException;
 
@@ -17,17 +14,12 @@ import java.util.Comparator;
 import static java.nio.file.StandardOpenOption.CREATE;
 import static java.nio.file.StandardOpenOption.TRUNCATE_EXISTING;
 
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class ContentService {
 
-    private static final ContentService INSTANCE = new ContentService();
+    private final Path basePath;
 
-    private static final Path BASE_PATH = Path.of(
-            Config.required("app.content.base-path")
-    ).toAbsolutePath().normalize();
-
-    public static ContentService getInstance() {
-        return INSTANCE;
+    public ContentService(Path basePath) {
+        this.basePath = basePath.toAbsolutePath().normalize();
     }
 
     public void upload(InputStream inputStream, String contentPath) {
@@ -128,8 +120,8 @@ public class ContentService {
             throw new IllegalArgumentException("contentPath is required");
         }
         String clean = contentPath.startsWith("/") ? contentPath.substring(1) : contentPath;
-        Path full = BASE_PATH.resolve(clean).normalize();
-        if (!full.startsWith(BASE_PATH)) {
+        Path full = basePath.resolve(clean).normalize();
+        if (!full.startsWith(basePath)) {
             throw new SecurityException("invalid content path");
         }
         return full;

--- a/back/src/main/java/ru/andrewb/charm/back/service/ProfileService.java
+++ b/back/src/main/java/ru/andrewb/charm/back/service/ProfileService.java
@@ -1,8 +1,5 @@
 package ru.andrewb.charm.back.service;
 
-
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import ru.andrewb.charm.back.dao.ProfileDao;
 import ru.andrewb.charm.back.dto.*;
@@ -23,20 +20,26 @@ import java.util.List;
 import java.util.Optional;
 
 @Slf4j
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class ProfileService {
 
-    private static final ProfileService INSTANCE = new ProfileService();
+    private final ProfileDao dao;
+    private final ContentService contentService;
+    private final ProfileToProfileGetDtoMapper profileToProfileGetDtoMapper;
+    private final ProfileUpdateDtoToProfileMapper profileUpdateDtoToProfileMapper;
+    private final ProfileToUserDetailsDtoMapper profileToUserDetailsDtoMapper;
 
-    private final ProfileDao dao = ProfileDao.getInstance();
-    private final ContentService contentService = ContentService.getInstance();
-
-    private final ProfileToProfileGetDtoMapper profileToProfileGetDtoMapper = ProfileToProfileGetDtoMapper.getInstance();
-    private final ProfileUpdateDtoToProfileMapper profileUpdateDtoToProfileMapper = ProfileUpdateDtoToProfileMapper.getInstance();
-    private final ProfileToUserDetailsDtoMapper profileToUserDetailsDtoMapper = ProfileToUserDetailsDtoMapper.getInstance();
-
-    public static ProfileService getInstance() {
-        return INSTANCE;
+    public ProfileService(
+            ProfileDao dao,
+            ContentService contentService,
+            ProfileToProfileGetDtoMapper profileToProfileGetDtoMapper,
+            ProfileUpdateDtoToProfileMapper profileUpdateDtoToProfileMapper,
+            ProfileToUserDetailsDtoMapper profileToUserDetailsDtoMapper
+    ) {
+        this.dao = dao;
+        this.contentService = contentService;
+        this.profileToProfileGetDtoMapper = profileToProfileGetDtoMapper;
+        this.profileUpdateDtoToProfileMapper = profileUpdateDtoToProfileMapper;
+        this.profileToUserDetailsDtoMapper = profileToUserDetailsDtoMapper;
     }
 
     public Long save(RegistrationDto dto) {

--- a/back/src/test/java/ru/andrewb/charm/back/mapper/ProfileToProfileGetDtoMapperTest.java
+++ b/back/src/test/java/ru/andrewb/charm/back/mapper/ProfileToProfileGetDtoMapperTest.java
@@ -1,0 +1,89 @@
+package ru.andrewb.charm.back.mapper;
+
+import org.junit.jupiter.api.Test;
+import ru.andrewb.charm.back.dto.ProfileGetDto;
+import ru.andrewb.charm.back.model.Gender;
+import ru.andrewb.charm.back.model.Profile;
+import ru.andrewb.charm.back.model.Role;
+import ru.andrewb.charm.back.model.Status;
+
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ProfileToProfileGetDtoMapperTest {
+
+    private final ProfileToProfileGetDtoMapper mapper = ProfileToProfileGetDtoMapper.getInstance();
+
+    @Test
+    void map_shouldCopyAllFieldsAndCalculateAge() {
+        LocalDate birthdate = LocalDate.now().minusYears(25).plusDays(1);
+
+        Profile profile = new Profile();
+        profile.setId(1L);
+        profile.setVersion(7);
+        profile.setEmail("user@mail.com");
+        profile.setName("Ivan");
+        profile.setSurname("Ivanov");
+        profile.setAbout("About");
+        profile.setBirthdate(birthdate);
+        profile.setGender(Gender.MALE);
+        profile.setStatus(Status.ACTIVE);
+        profile.setPhoto("photo.jpg");
+        profile.setRole(Role.USER);
+
+        ProfileGetDto dto = mapper.map(profile);
+
+        assertEquals(1L, dto.getId());
+        assertEquals(7, dto.getVersion());
+        assertEquals("user@mail.com", dto.getEmail());
+        assertEquals("Ivan", dto.getName());
+        assertEquals("Ivanov", dto.getSurname());
+        assertEquals("About", dto.getAbout());
+        assertEquals(birthdate, dto.getBirthdate());
+        assertEquals(
+                Math.toIntExact(ChronoUnit.YEARS.between(birthdate, LocalDate.now())),
+                dto.getAge()
+        );
+        assertEquals(Gender.MALE, dto.getGender());
+        assertEquals(Status.ACTIVE, dto.getStatus());
+        assertEquals("photo.jpg", dto.getPhoto());
+        assertEquals(Role.USER, dto.getRole());
+    }
+
+    @Test
+    void map_shouldSetAgeToNull_whenBirthdateIsNull() {
+        Profile  profile = new Profile();
+        profile.setId(1L);
+        profile.setBirthdate(null);
+
+        ProfileGetDto dto = mapper.map(profile);
+
+        assertEquals(1L, dto.getId());
+        assertNull(dto.getBirthdate());
+        assertNull(dto.getAge());
+    }
+
+    @Test
+    void map_shouldFillProvidedTargetDto() {
+        Profile profile = new Profile();
+        profile.setId(10L);
+        profile.setEmail("new@mail.com");
+        profile.setName("Ivan");
+        profile.setSurname("Ivanov");
+        profile.setRole(Role.ADMIN);
+
+        ProfileGetDto target = new ProfileGetDto();
+        target.setEmail("old@mail.com");
+
+        ProfileGetDto result = mapper.map(profile, target);
+
+        assertSame(target, result);
+        assertEquals(10L, target.getId());
+        assertEquals("new@mail.com", target.getEmail());
+        assertEquals("Ivan", target.getName());
+        assertEquals("Ivanov", target.getSurname());
+        assertEquals(Role.ADMIN, target.getRole());
+    }
+}

--- a/back/src/test/java/ru/andrewb/charm/back/mapper/ProfileToUserDetailsDtoMapperTest.java
+++ b/back/src/test/java/ru/andrewb/charm/back/mapper/ProfileToUserDetailsDtoMapperTest.java
@@ -1,0 +1,65 @@
+package ru.andrewb.charm.back.mapper;
+
+import org.junit.jupiter.api.Test;
+import ru.andrewb.charm.back.dto.UserDetailsDto;
+import ru.andrewb.charm.back.model.Profile;
+import ru.andrewb.charm.back.model.Role;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class ProfileToUserDetailsDtoMapperTest {
+
+    private final ProfileToUserDetailsDtoMapper mapper = ProfileToUserDetailsDtoMapper.getInstance();
+
+    @Test
+    void map_shouldCopyIdEmailRole() {
+        Profile profile = new Profile();
+        profile.setId(1L);
+        profile.setEmail("admin@mail.com");
+        profile.setRole(Role.ADMIN);
+
+        UserDetailsDto dto = mapper.map(profile);
+
+        assertEquals(1L, dto.getId());
+        assertEquals("admin@mail.com", dto.getEmail());
+        assertEquals(Role.ADMIN, dto.getRole());
+    }
+
+    @Test
+    void map_shouldFillProvidedTargetDto() {
+        Profile profile = new Profile();
+        profile.setId(12L);
+        profile.setEmail("user@mail.com");
+        profile.setRole(Role.USER);
+
+        UserDetailsDto target = new UserDetailsDto();
+        target.setEmail("old@mail.com");
+
+        UserDetailsDto result = mapper.map(profile, target);
+
+        assertSame(target, result);
+        assertEquals(12L, target.getId());
+        assertEquals("user@mail.com", target.getEmail());
+        assertEquals(Role.USER, target.getRole());
+    }
+
+    @Test
+    void map_shouldOverwritePreviousValuesInTargetDto() {
+        Profile profile = new Profile();
+        profile.setId(99L);
+        profile.setEmail("new@mail.com");
+        profile.setRole(Role.USER);
+
+        UserDetailsDto target = new UserDetailsDto();
+        target.setId(1L);
+        target.setEmail("old@mail.com");
+        target.setRole(Role.ADMIN);
+
+        mapper.map(profile, target);
+
+        assertEquals(99L, target.getId());
+        assertEquals("new@mail.com", target.getEmail());
+        assertEquals(Role.USER, target.getRole());
+    }
+}

--- a/back/src/test/java/ru/andrewb/charm/back/mapper/ProfileUpdateDtoToProfileMapperTest.java
+++ b/back/src/test/java/ru/andrewb/charm/back/mapper/ProfileUpdateDtoToProfileMapperTest.java
@@ -1,0 +1,104 @@
+package ru.andrewb.charm.back.mapper;
+
+import org.junit.jupiter.api.Test;
+import ru.andrewb.charm.back.dto.ProfileUpdateDto;
+import ru.andrewb.charm.back.model.Gender;
+import ru.andrewb.charm.back.model.Profile;
+import ru.andrewb.charm.back.model.Status;
+
+import java.time.LocalDate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class ProfileUpdateDtoToProfileMapperTest {
+
+    private final ProfileUpdateDtoToProfileMapper mapper = ProfileUpdateDtoToProfileMapper.getInstance();
+
+    @Test
+    void map_shouldCopyAllNonNullFieldsToNewProfile() {
+        ProfileUpdateDto dto = new ProfileUpdateDto();
+        dto.setVersion(1);
+        dto.setName("Ivan");
+        dto.setSurname("Ivanov");
+        dto.setBirthdate(LocalDate.of(2000, 1, 1));
+        dto.setAbout("About");
+        dto.setGender(Gender.MALE);
+        dto.setStatus(Status.ACTIVE);
+
+        Profile profile = mapper.map(dto);
+
+        assertEquals(1, profile.getVersion());
+        assertEquals("Ivan", profile.getName());
+        assertEquals("Ivanov", profile.getSurname());
+        assertEquals(LocalDate.of(2000, 1, 1), profile.getBirthdate());
+        assertEquals("About", profile.getAbout());
+        assertEquals(Gender.MALE, profile.getGender());
+        assertEquals(Status.ACTIVE, profile.getStatus());
+    }
+
+    @Test
+    void map_shouldUpdateOnlyNonNullFieldsInExistingProfile() {
+        ProfileUpdateDto dto = new ProfileUpdateDto();
+        dto.setName("New name");
+        dto.setAbout("New about");
+        dto.setStatus(Status.INACTIVE);
+
+        Profile profile = new Profile();
+        profile.setVersion(1);
+        profile.setName("Old name");
+        profile.setSurname("Old surname");
+        profile.setBirthdate(LocalDate.of(1999, 2, 2));
+        profile.setAbout("Old about");
+        profile.setGender(Gender.FEMALE);
+        profile.setStatus(Status.ACTIVE);
+
+        Profile result = mapper.map(dto, profile);
+
+        assertSame(profile, result);
+        assertEquals(1, profile.getVersion());
+        assertEquals("New name", profile.getName());
+        assertEquals("Old surname", profile.getSurname());
+        assertEquals(LocalDate.of(1999, 2, 2), profile.getBirthdate());
+        assertEquals("New about", profile.getAbout());
+        assertEquals(Gender.FEMALE, profile.getGender());
+        assertEquals(Status.INACTIVE, profile.getStatus());
+    }
+
+    @Test
+    void map_shouldUpdateVersionWhenProvided() {
+        ProfileUpdateDto dto = new ProfileUpdateDto();
+        dto.setVersion(99);
+
+        Profile profile = new Profile();
+        profile.setVersion(1);
+
+        mapper.map(dto, profile);
+
+        assertEquals(99, profile.getVersion());
+    }
+
+    @Test
+    void map_shouldNotOverwriteFieldsWithNulls() {
+        ProfileUpdateDto dto = new ProfileUpdateDto();
+
+        Profile profile = new Profile();
+        profile.setVersion(5);
+        profile.setName("Ivan");
+        profile.setSurname("Ivanov");
+        profile.setBirthdate(LocalDate.of(2001, 3, 4));
+        profile.setAbout("About");
+        profile.setGender(Gender.MALE);
+        profile.setStatus(Status.ACTIVE);
+
+        mapper.map(dto, profile);
+
+        assertEquals(5, profile.getVersion());
+        assertEquals("Ivan", profile.getName());
+        assertEquals("Ivanov", profile.getSurname());
+        assertEquals(LocalDate.of(2001, 3, 4), profile.getBirthdate());
+        assertEquals("About", profile.getAbout());
+        assertEquals(Gender.MALE, profile.getGender());
+        assertEquals(Status.ACTIVE, profile.getStatus());
+    }
+}

--- a/back/src/test/java/ru/andrewb/charm/back/normalizer/CharmDtoDefaultsTest.java
+++ b/back/src/test/java/ru/andrewb/charm/back/normalizer/CharmDtoDefaultsTest.java
@@ -1,0 +1,58 @@
+package ru.andrewb.charm.back.normalizer;
+
+import org.junit.jupiter.api.Test;
+import ru.andrewb.charm.back.dto.Action;
+import ru.andrewb.charm.back.dto.CharmDto;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CharmDtoDefaultsTest {
+
+    @Test
+    void normalize_shouldSetDefaultActionToSkip_whenActionIsNull() {
+        CharmDto dto = new CharmDto();
+        dto.setToProfileId(42L);
+
+        CharmDto result = CharmDtoDefaults.normalize(dto);
+
+        assertSame(dto, result);
+        assertEquals(Action.SKIP, result.getAction());
+        assertNull(result.getToProfileId());
+    }
+
+    @Test
+    void normalize_shouldClearToProfileId_whenActionIsSkip() {
+        CharmDto dto = new CharmDto();
+        dto.setAction(Action.SKIP);
+        dto.setToProfileId(42L);
+
+        CharmDto result = CharmDtoDefaults.normalize(dto);
+
+        assertEquals(Action.SKIP, result.getAction());
+        assertNull(result.getToProfileId());
+    }
+
+    @Test
+    void normalize_shouldKeepToProfileId_whenActionIsLike() {
+        CharmDto dto = new CharmDto();
+        dto.setAction(Action.LIKE);
+        dto.setToProfileId(42L);
+
+        CharmDto result = CharmDtoDefaults.normalize(dto);
+
+        assertEquals(Action.LIKE, result.getAction());
+        assertEquals(42L, result.getToProfileId());
+    }
+
+    @Test
+    void normalize_shouldKeepToProfileId_whenActionIsDislike() {
+        CharmDto dto = new CharmDto();
+        dto.setAction(Action.DISLIKE);
+        dto.setToProfileId(42L);
+
+        CharmDto result = CharmDtoDefaults.normalize(dto);
+
+        assertEquals(Action.DISLIKE, result.getAction());
+        assertEquals(42L, result.getToProfileId());
+    }
+}

--- a/back/src/test/java/ru/andrewb/charm/back/normalizer/ProfileFilterDefaultsTest.java
+++ b/back/src/test/java/ru/andrewb/charm/back/normalizer/ProfileFilterDefaultsTest.java
@@ -1,0 +1,91 @@
+package ru.andrewb.charm.back.normalizer;
+
+import org.junit.jupiter.api.Test;
+import ru.andrewb.charm.back.dto.ProfileFilter;
+import ru.andrewb.charm.back.dto.sort.SortBy;
+import ru.andrewb.charm.back.dto.sort.SortOrder;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class ProfileFilterDefaultsTest {
+
+    @Test
+    void normalize_shouldApplyAllDefaults_whenFieldsAreNull() {
+        ProfileFilter filter = new ProfileFilter();
+
+        ProfileFilter result = ProfileFilterDefaults.normalize(filter);
+
+        assertSame(filter, result);
+        assertEquals(SortBy.ID, filter.getSortBy());
+        assertEquals(SortOrder.ASC, filter.getSortOrder());
+        assertEquals(1, filter.getPage());
+        assertEquals(10, filter.getPageSize());
+    }
+
+    @Test
+    void normalize_shouldKeepExplicitSortSettings() {
+        ProfileFilter filter = new ProfileFilter();
+        filter.setSortBy(SortBy.EMAIL);
+        filter.setSortOrder(SortOrder.DESC);
+        filter.setPage(2);
+        filter.setPageSize(20);
+
+        ProfileFilterDefaults.normalize(filter);
+
+        assertEquals(SortBy.EMAIL, filter.getSortBy());
+        assertEquals(SortOrder.DESC, filter.getSortOrder());
+        assertEquals(2, filter.getPage());
+        assertEquals(20, filter.getPageSize());
+    }
+
+    @Test
+    void normalize_shouldSetDefaultPage_whenPageIsNull() {
+        ProfileFilter filter = new ProfileFilter();
+        filter.setPage(null);
+
+        ProfileFilterDefaults.normalize(filter);
+
+        assertEquals(1, filter.getPage());
+    }
+
+    @Test
+    void normalize_shouldSetDefaultPageSize_whenPageSizeIsNull() {
+        ProfileFilter filter = new ProfileFilter();
+        filter.setPageSize(null);
+
+        ProfileFilterDefaults.normalize(filter);
+
+        assertEquals(10, filter.getPageSize());
+    }
+
+    @Test
+    void normalize_shouldKeepPageSize_whenItIsAllowed() {
+        ProfileFilter filter = new ProfileFilter();
+        filter.setPageSize(50);
+
+        ProfileFilterDefaults.normalize(filter);
+
+        assertEquals(50, filter.getPageSize());
+    }
+
+    @Test
+    void normalize_shouldSetDefaultPage_whenPageIsLessThanOne() {
+        ProfileFilter filter = new ProfileFilter();
+        filter.setPage(0);
+
+        ProfileFilterDefaults.normalize(filter);
+
+        assertEquals(1, filter.getPage());
+    }
+
+    @Test
+    void normalize_shouldSetDefaultPageSize_whenPageSizeIsNotAllowed() {
+        ProfileFilter filter = new ProfileFilter();
+        filter.setPageSize(15);
+
+        ProfileFilterDefaults.normalize(filter);
+
+        assertEquals(10, filter.getPageSize());
+    }
+}

--- a/back/src/test/java/ru/andrewb/charm/back/security/AuthUtilsTest.java
+++ b/back/src/test/java/ru/andrewb/charm/back/security/AuthUtilsTest.java
@@ -1,0 +1,152 @@
+package ru.andrewb.charm.back.security;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+import org.junit.jupiter.api.Test;
+import ru.andrewb.charm.back.dto.UserDetailsDto;
+import ru.andrewb.charm.back.model.Role;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class AuthUtilsTest {
+
+    @Test
+    void getUserOrNull_shouldReturnNull_whenSessionDoesNotExist() {
+        HttpServletRequest req = mock(HttpServletRequest.class);
+        when(req.getSession(false)).thenReturn(null);
+
+        UserDetailsDto result = AuthUtils.getUserOrNull(req);
+
+        assertNull(result);
+    }
+
+    @Test
+    void getUserOrNull_shouldReturnUser_whenSessionContainsUserDetails() {
+        HttpServletRequest req = mock(HttpServletRequest.class);
+        HttpSession session = mock(HttpSession.class);
+
+        UserDetailsDto user = new UserDetailsDto();
+        user.setId(1L);
+        user.setEmail("user@mail.com");
+        user.setRole(Role.USER);
+
+        when(req.getSession(false)).thenReturn(session);
+        when(session.getAttribute("userDetails")).thenReturn(user);
+
+        UserDetailsDto result = AuthUtils.getUserOrNull(req);
+
+        assertSame(user, result);
+    }
+
+    @Test
+    void getAuthCtx_shouldReturnNull_whenUserIsNotAuthenticated() {
+        HttpServletRequest req = mock(HttpServletRequest.class);
+        when(req.getSession(false)).thenReturn(null);
+
+        AuthUtils.Ctx result = AuthUtils.getAuthCtx(req);
+
+        assertNull(result);
+    }
+
+    @Test
+    void getAuthCtx_shouldUseCurrentUserId_whenIdParamIsMissing() {
+        HttpServletRequest req = mock(HttpServletRequest.class);
+        HttpSession session = mock(HttpSession.class);
+
+        UserDetailsDto user = new UserDetailsDto();
+        user.setId(15L);
+        user.setRole(Role.USER);
+
+        when(req.getSession(false)).thenReturn(session);
+        when(session.getAttribute("userDetails")).thenReturn(user);
+        when(req.getParameter("id")).thenReturn(null);
+
+        AuthUtils.Ctx ctx = AuthUtils.getAuthCtx(req);
+
+        assertNotNull(ctx);
+        assertSame(user, ctx.user());
+        assertEquals(15L, ctx.targetId());
+        assertFalse(ctx.isAdmin());
+    }
+
+    @Test
+    void getAuthCtx_shouldUseCurrentUserId_whenIdParamIsBlank() {
+        HttpServletRequest req = mock(HttpServletRequest.class);
+        HttpSession session = mock(HttpSession.class);
+
+        UserDetailsDto user = new UserDetailsDto();
+        user.setId(20L);
+        user.setRole(Role.USER);
+
+        when(req.getSession(false)).thenReturn(session);
+        when(session.getAttribute("userDetails")).thenReturn(user);
+        when(req.getParameter("id")).thenReturn("   ");
+
+        AuthUtils.Ctx ctx = AuthUtils.getAuthCtx(req);
+
+        assertNotNull(ctx);
+        assertEquals(20L, ctx.targetId());
+        assertFalse(ctx.isAdmin());
+    }
+
+    @Test
+    void getAuthCtx_shouldUseRequestedId_whenUserIsAdminAndIdParamIsPresent() {
+        HttpServletRequest req = mock(HttpServletRequest.class);
+        HttpSession session = mock(HttpSession.class);
+
+        UserDetailsDto admin = new UserDetailsDto();
+        admin.setId(1L);
+        admin.setRole(Role.ADMIN);
+
+        when(req.getSession(false)).thenReturn(session);
+        when(session.getAttribute("userDetails")).thenReturn(admin);
+        when(req.getParameter("id")).thenReturn("42");
+
+        AuthUtils.Ctx ctx = AuthUtils.getAuthCtx(req);
+
+        assertNotNull(ctx);
+        assertSame(admin, ctx.user());
+        assertEquals(42L, ctx.targetId());
+        assertTrue(ctx.isAdmin());
+    }
+
+    @Test
+    void isAuthenticatedAdmin_shouldReturnTrue_whenUserIsAdmin() {
+        HttpServletRequest req = mock(HttpServletRequest.class);
+        HttpSession session = mock(HttpSession.class);
+
+        UserDetailsDto admin = new UserDetailsDto();
+        admin.setId(1L);
+        admin.setRole(Role.ADMIN);
+
+        when(req.getSession(false)).thenReturn(session);
+        when(session.getAttribute("userDetails")).thenReturn(admin);
+
+        assertTrue(AuthUtils.isAuthenticatedAdmin(req));
+    }
+
+    @Test
+    void isAuthenticatedAdmin_shouldReturnFalse_whenUserIsNotAdmin() {
+        HttpServletRequest req = mock(HttpServletRequest.class);
+        HttpSession session = mock(HttpSession.class);
+
+        UserDetailsDto user = new UserDetailsDto();
+        user.setId(2L);
+        user.setRole(Role.USER);
+
+        when(req.getSession(false)).thenReturn(session);
+        when(session.getAttribute("userDetails")).thenReturn(user);
+
+        assertFalse(AuthUtils.isAuthenticatedAdmin(req));
+    }
+
+    @Test
+    void isAuthenticatedAdmin_shouldReturnFalse_whenUserIsMissing() {
+        HttpServletRequest req = mock(HttpServletRequest.class);
+        when(req.getSession(false)).thenReturn(null);
+
+        assertFalse(AuthUtils.isAuthenticatedAdmin(req));
+    }
+}

--- a/back/src/test/java/ru/andrewb/charm/back/security/PasswordHasherTest.java
+++ b/back/src/test/java/ru/andrewb/charm/back/security/PasswordHasherTest.java
@@ -1,0 +1,33 @@
+package ru.andrewb.charm.back.security;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PasswordHasherTest {
+
+    @Test
+    void hashPwd_shouldCreateHashDifferentFromSource() {
+        String raw = "password";
+        String hash = PasswordHasher.hashPwd(raw);
+
+        assertNotNull(hash);
+        assertNotEquals(raw, hash);
+    }
+
+    @Test
+    void checkPwd_shouldReturnTrue_forMatchingPassword() {
+        String raw = "password";
+        String hash = PasswordHasher.hashPwd(raw);
+
+        assertTrue(PasswordHasher.checkPwd(raw, hash));
+    }
+
+    @Test
+    void checkPwd_shouldReturnFalse_forNonMatchingPassword() {
+        String wrongRaw = "wrong";
+        String correctHash = PasswordHasher.hashPwd("correct");
+
+        assertFalse(PasswordHasher.checkPwd(wrongRaw, correctHash));
+    }
+}

--- a/back/src/test/java/ru/andrewb/charm/back/security/SecurityRulesTest.java
+++ b/back/src/test/java/ru/andrewb/charm/back/security/SecurityRulesTest.java
@@ -1,0 +1,100 @@
+package ru.andrewb.charm.back.security;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SecurityRulesTest {
+
+    @Test
+    void isPublicUi_shouldReturnTrueForLogin() {
+        assertTrue(SecurityRules.isPublicUi("/login"));
+    }
+
+    @Test
+    void isPublicUi_shouldReturnFalseForProfile() {
+        assertFalse(SecurityRules.isPublicUi("/profile"));
+    }
+
+    @Test
+    void isPublicUi_shouldReturnTrue_forStaticAsset() {
+        assertTrue(SecurityRules.isPublicUi("/img/logo.png"));
+    }
+
+    @Test
+    void isRest_shouldReturnTrue_forApiPath() {
+        assertTrue(SecurityRules.isRest("/api/v1/profile"));
+    }
+
+    @Test
+    void isRest_shouldReturnFalse_forUiPath() {
+        assertFalse(SecurityRules.isRest("/profile"));
+    }
+
+    @Test
+    void isSafeInternalRedirect_shouldAllowSafeInternalPath() {
+        boolean result = SecurityRules.isSafeInternalRedirect(
+                "/app",
+                "/app/profiles?page=2",
+                "/profiles"
+        );
+
+        assertTrue(result);
+    }
+
+    @Test
+    void isSafeInternalRedirect_shouldRejectAbsoluteUrl() {
+        boolean result = SecurityRules.isSafeInternalRedirect(
+                "/app",
+                "https://evil.com/app/profiles",
+                "/profiles"
+        );
+
+        assertFalse(result);
+    }
+
+    @Test
+    void isSafeInternalRedirect_shouldRejectPathOutsideContext() {
+        boolean result = SecurityRules.isSafeInternalRedirect(
+                "/app",
+                "/other/profiles",
+                "/profiles"
+        );
+
+        assertFalse(result);
+    }
+
+    @Test
+    void isSafeInternalRedirect_shouldRejectPathTraversal() {
+        boolean result = SecurityRules.isSafeInternalRedirect(
+                "/app",
+                "/app/../admin",
+                "/profiles"
+        );
+
+        assertFalse(result);
+    }
+
+    @Test
+    void isSafeInternalRedirect_shouldRejectCrLfInjection() {
+        boolean result = SecurityRules.isSafeInternalRedirect(
+                "/app",
+                "/app/profiles%0d%0aLocation:https://evil.com",
+                "/profiles"
+        );
+
+        assertFalse(result);
+    }
+
+    @Test
+    void isSafeInternalRedirect_shouldRejectNotAllowedPrefix() {
+        boolean result = SecurityRules.isSafeInternalRedirect(
+                "/app",
+                "/app/settings",
+                "/profiles"
+        );
+
+        assertFalse(result);
+    }
+}

--- a/back/src/test/java/ru/andrewb/charm/back/service/CharmServiceTest.java
+++ b/back/src/test/java/ru/andrewb/charm/back/service/CharmServiceTest.java
@@ -1,0 +1,209 @@
+package ru.andrewb.charm.back.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import ru.andrewb.charm.back.dao.ProfileDao;
+import ru.andrewb.charm.back.dao.ProfileLikeDao;
+import ru.andrewb.charm.back.dto.Action;
+import ru.andrewb.charm.back.dto.CharmDto;
+import ru.andrewb.charm.back.dto.ProfileSimpleDto;
+
+import java.util.ArrayDeque;
+import java.util.Optional;
+import java.util.Queue;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class CharmServiceTest {
+
+    @Mock
+    private ProfileDao profileDao;
+
+    @Mock
+    private ProfileLikeDao profileLikeDao;
+
+    @Mock
+    private ProfileCacheService profileCacheService;
+
+    private CharmService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new CharmService(
+                profileDao,
+                profileLikeDao,
+                profileCacheService
+        );
+    }
+
+    @Test
+    void getNext_shouldReturnCandidateFromCache_whenCacheHasValue() {
+        CharmDto dto = buildDto(1L, 2L, Action.SKIP);
+        ProfileSimpleDto cached = candidate(100L, "Cached");
+
+        when(profileCacheService.pollNext(1L)).thenReturn(cached);
+
+        Optional<ProfileSimpleDto> result = service.getNext(dto);
+
+        assertTrue(result.isPresent());
+        assertSame(cached, result.get());
+
+        verify(profileCacheService).pollNext(1L);
+        verify(profileCacheService, never()).isEmptyCooldownActive(anyLong());
+        verify(profileCacheService, never()).tryAcquireLock(anyLong());
+        verify(profileDao, never()).findSuitableForUser(anyLong(), anyInt());
+        verify(profileLikeDao, never()).likeOrDislike(anyLong(), anyLong(), anyBoolean());
+    }
+
+    @Test
+    void getNext_shouldCallLikeOrDislike_beforeFetchingNext_whenActionIsLike() {
+        CharmDto dto = buildDto(2L, 3L, Action.LIKE);
+        ProfileSimpleDto cached = candidate(200L, "Cached");
+
+        when(profileCacheService.pollNext(2L)).thenReturn(cached);
+
+        Optional<ProfileSimpleDto> result = service.getNext(dto);
+
+        assertTrue(result.isPresent());
+        assertSame(cached, result.get());
+
+        verify(profileLikeDao).likeOrDislike(2L, 3L, true);
+        verify(profileCacheService).pollNext(2L);
+    }
+
+    @Test
+    void getNext_shouldCallLikeOrDislikeWithFalse_whenActionIsDislike() {
+        CharmDto dto = buildDto(3L, 4L, Action.DISLIKE);
+        ProfileSimpleDto cached = candidate(300L, "Cached");
+
+        when(profileCacheService.pollNext(3L)).thenReturn(cached);
+
+        Optional<ProfileSimpleDto> result = service.getNext(dto);
+
+        assertTrue(result.isPresent());
+        assertSame(cached, result.get());
+
+        verify(profileLikeDao).likeOrDislike(3L, 4L, false);
+        verify(profileCacheService).pollNext(3L);
+    }
+
+    @Test
+    void getNext_shouldNotCallLikeOrDislike_whenActionIsSkip() {
+        CharmDto dto = buildDto(1L, 2L, Action.SKIP);
+
+        when(profileCacheService.pollNext(1L)).thenReturn(null);
+        when(profileCacheService.isEmptyCooldownActive(1L)).thenReturn(true);
+
+        Optional<ProfileSimpleDto> result = service.getNext(dto);
+
+        assertTrue(result.isEmpty());
+
+        verify(profileLikeDao, never()).likeOrDislike(anyLong(), anyLong(), anyBoolean());
+    }
+
+    @Test
+    void getNext_shouldReturnEmpty_whenEmptyCooldownIsActive() {
+        CharmDto dto = buildDto(1L, null, Action.SKIP);
+
+        when(profileCacheService.pollNext(1L)).thenReturn(null);
+        when(profileCacheService.isEmptyCooldownActive(1L)).thenReturn(true);
+
+        Optional<ProfileSimpleDto> result = service.getNext(dto);
+
+        assertTrue(result.isEmpty());
+
+        verify(profileCacheService).pollNext(1L);
+        verify(profileCacheService).isEmptyCooldownActive(1L);
+        verify(profileCacheService, never()).tryAcquireLock(anyLong());
+        verify(profileDao, never()).findSuitableForUser(anyLong(), anyInt());
+    }
+
+    @Test
+    void getNext_shouldReturnEmpty_whenLockIsNotAcquired() {
+        CharmDto dto = buildDto(1L, null, Action.SKIP);
+
+        when(profileCacheService.pollNext(1L)).thenReturn(null);
+        when(profileCacheService.isEmptyCooldownActive(1L)).thenReturn(false);
+        when(profileCacheService.tryAcquireLock(1L)).thenReturn(null);
+
+        Optional<ProfileSimpleDto> result = service.getNext(dto);
+
+        assertTrue(result.isEmpty());
+
+        verify(profileCacheService).pollNext(1L);
+        verify(profileCacheService).isEmptyCooldownActive(1L);
+        verify(profileCacheService).tryAcquireLock(1L);
+        verify(profileDao, never()).findSuitableForUser(anyLong(), anyInt());
+        verify(profileCacheService, never()).releaseLock(anyLong(), any());
+    }
+
+    @Test
+    void getNext_shouldRefillFromDaoAndCacheRest_whenLockIsAcquired() {
+        CharmDto dto = buildDto(1L, null, Action.SKIP);
+
+        ProfileSimpleDto first = candidate(10L, "First");
+        ProfileSimpleDto second = candidate(11L, "Second");
+        Queue<ProfileSimpleDto> queue = new ArrayDeque<>();
+        queue.add(first);
+        queue.add(second);
+
+        when(profileCacheService.pollNext(1L)).thenReturn(null);
+        when(profileCacheService.isEmptyCooldownActive(1L)).thenReturn(false);
+        when(profileCacheService.tryAcquireLock(1L)).thenReturn("token-1");
+        when(profileDao.findSuitableForUser(1L, 5)).thenReturn(queue);
+
+        Optional<ProfileSimpleDto> result = service.getNext(dto);
+
+        assertTrue(result.isPresent());
+        assertSame(first, result.get());
+
+        verify(profileDao).findSuitableForUser(1L, 5);
+        verify(profileCacheService).clearEmptyCooldown(1L);
+        verify(profileCacheService).replaceQueue(eq(1L), any(Queue.class));
+        verify(profileCacheService).releaseLock(1L, "token-1");
+        verify(profileCacheService, never()).markEmptyCooldown(anyLong());
+    }
+
+    @Test
+    void getNext_shouldReturnEmptyAndMarkCooldown_whenDaoReturnsNoCandidates() {
+        CharmDto dto = buildDto(1L, null, Action.SKIP);
+
+        Queue<ProfileSimpleDto> queue = new ArrayDeque<>();
+
+        when(profileCacheService.pollNext(1L)).thenReturn(null);
+        when(profileCacheService.isEmptyCooldownActive(1L)).thenReturn(false);
+        when(profileCacheService.tryAcquireLock(1L)).thenReturn("token-1");
+        when(profileDao.findSuitableForUser(1L, 5)).thenReturn(queue);
+
+        Optional<ProfileSimpleDto> result = service.getNext(dto);
+
+        assertTrue(result.isEmpty());
+
+        verify(profileDao).findSuitableForUser(1L, 5);
+        verify(profileCacheService).markEmptyCooldown(1L);
+        verify(profileCacheService, never()).clearEmptyCooldown(anyLong());
+        verify(profileCacheService, never()).replaceQueue(anyLong(), any());
+        verify(profileCacheService).releaseLock(1L, "token-1");
+    }
+
+    private CharmDto buildDto(Long fromId, Long toId, Action action) {
+        CharmDto dto = new CharmDto();
+        dto.setFromProfileId(fromId);
+        dto.setToProfileId(toId);
+        dto.setAction(action);
+        return dto;
+    }
+
+    private ProfileSimpleDto candidate(Long id, String name) {
+        ProfileSimpleDto dto = new ProfileSimpleDto();
+        dto.setId(id);
+        dto.setName(name);
+        return dto;
+    }
+}

--- a/back/src/test/java/ru/andrewb/charm/back/service/ProfileServiceChangeEmailTest.java
+++ b/back/src/test/java/ru/andrewb/charm/back/service/ProfileServiceChangeEmailTest.java
@@ -1,0 +1,209 @@
+package ru.andrewb.charm.back.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import ru.andrewb.charm.back.dao.ProfileDao;
+import ru.andrewb.charm.back.dto.EmailChangeDto;
+import ru.andrewb.charm.back.mapper.ProfileToProfileGetDtoMapper;
+import ru.andrewb.charm.back.mapper.ProfileToUserDetailsDtoMapper;
+import ru.andrewb.charm.back.mapper.ProfileUpdateDtoToProfileMapper;
+import ru.andrewb.charm.back.model.Profile;
+import ru.andrewb.charm.back.model.exception.BadRequestException;
+import ru.andrewb.charm.back.model.exception.DuplicateEmailException;
+import ru.andrewb.charm.back.model.exception.NotFoundException;
+import ru.andrewb.charm.back.security.PasswordHasher;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ProfileServiceChangeEmailTest {
+
+    @Mock
+    private ProfileDao dao;
+
+    @Mock
+    private ContentService contentService;
+
+    @Mock
+    private ProfileToProfileGetDtoMapper profileToProfileGetDtoMapper;
+
+    @Mock
+    private ProfileUpdateDtoToProfileMapper profileUpdateDtoToProfileMapper;
+
+    @Mock
+    private ProfileToUserDetailsDtoMapper profileToUserDetailsDtoMapper;
+
+    private ProfileService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new ProfileService(
+                dao,
+                contentService,
+                profileToProfileGetDtoMapper,
+                profileUpdateDtoToProfileMapper,
+                profileToUserDetailsDtoMapper
+        );
+    }
+
+    @Test
+    void changeEmail_shouldUpdateEmail_whenInputIsValid() {
+        long profileId = 1L;
+
+        EmailChangeDto dto = new EmailChangeDto();
+        dto.setVersion(5);
+        dto.setNewEmail("new@mail.com");
+        dto.setCurrentPassword("123456");
+
+        Profile profile = new Profile();
+        profile.setId(profileId);
+        profile.setVersion(1);
+        profile.setEmail("old@mail.com");
+        profile.setPassword(PasswordHasher.hashPwd("123456"));
+
+        when(dao.findById(profileId)).thenReturn(Optional.of(profile));
+        when(dao.existsEmail("new@mail.com", profileId)).thenReturn(false);
+
+        service.changeEmail(profileId, dto);
+
+        assertEquals(5, profile.getVersion());
+        assertEquals("new@mail.com", profile.getEmail());
+        verify(dao).findById(profileId);
+        verify(dao).existsEmail("new@mail.com", profileId);
+        verify(dao).update(profile);
+    }
+
+    @Test
+    void changeEmail_shouldThrowNotFoundException_whenProfileDoesNotExist() {
+        long profileId = 1L;
+
+        EmailChangeDto dto = new EmailChangeDto();
+        dto.setVersion(1);
+        dto.setNewEmail("new@mail.com");
+        dto.setCurrentPassword("123456");
+
+        when(dao.findById(profileId)).thenReturn(Optional.empty());
+
+        NotFoundException ex = assertThrows(
+                NotFoundException.class,
+                () -> service.changeEmail(profileId, dto)
+        );
+
+        assertEquals("error.profile.not-found", ex.getMessage());
+        verify(dao).findById(profileId);
+        verify(dao, never()).update(any());
+    }
+
+    @Test
+    void changeEmail_shouldThrowBadRequestException_whenVersionIsMissing() {
+        long profileId = 1L;
+
+        EmailChangeDto dto = new EmailChangeDto();
+        dto.setVersion(null);
+        dto.setNewEmail("new@mail.com");
+        dto.setCurrentPassword("123456");
+
+        Profile profile = new Profile();
+        profile.setId(profileId);
+        profile.setEmail("old@mail.com");
+        profile.setPassword(PasswordHasher.hashPwd("123456"));
+
+        when(dao.findById(profileId)).thenReturn(Optional.of(profile));
+
+        BadRequestException ex = assertThrows(
+                BadRequestException.class,
+                () -> service.changeEmail(profileId, dto)
+        );
+
+        assertEquals("error.param.required", ex.getMessage());
+        verify(dao).findById(profileId);
+        verify(dao, never()).update(any());
+    }
+
+    @Test
+    void changeEmail_shouldThrowBadRequestException_whenCurrentPasswordIsIncorrect() {
+        long profileId = 1L;
+
+        EmailChangeDto dto = new EmailChangeDto();
+        dto.setVersion(1);
+        dto.setNewEmail("new@mail.com");
+        dto.setCurrentPassword("wrong-password");
+
+        Profile existing = new Profile();
+        existing.setId(profileId);
+        existing.setEmail("old@mail.com");
+        existing.setPassword(PasswordHasher.hashPwd("123456"));
+
+        when(dao.findById(profileId)).thenReturn(Optional.of(existing));
+
+        BadRequestException ex = assertThrows(
+                BadRequestException.class,
+                () -> service.changeEmail(profileId, dto)
+        );
+
+        assertEquals("error.password.invalid-current", ex.getMessage());
+        verify(dao).findById(profileId);
+        verify(dao, never()).update(any());
+    }
+
+    @Test
+    void changeEmail_shouldThrowBadRequestException_whenNewEmailMatchesCurrentEmailIgnoringCase() {
+        long profileId = 1L;
+
+        EmailChangeDto dto = new EmailChangeDto();
+        dto.setVersion(1);
+        dto.setNewEmail("OLD@mail.com");
+        dto.setCurrentPassword("123456");
+
+        Profile existing = new Profile();
+        existing.setId(profileId);
+        existing.setEmail("old@mail.com");
+        existing.setPassword(PasswordHasher.hashPwd("123456"));
+
+        when(dao.findById(profileId)).thenReturn(Optional.of(existing));
+
+        BadRequestException ex = assertThrows(
+                BadRequestException.class,
+                () -> service.changeEmail(profileId, dto)
+        );
+
+        assertEquals("error.email.same-as-current", ex.getMessage());
+        verify(dao).findById(profileId);
+        verify(dao, never()).update(any());
+    }
+
+    @Test
+    void changeEmail_shouldThrowDuplicateEmailException_whenNewEmailIsAlreadyTaken() {
+        long profileId = 1L;
+
+        EmailChangeDto dto = new EmailChangeDto();
+        dto.setVersion(1);
+        dto.setNewEmail("new@mail.com");
+        dto.setCurrentPassword("123456");
+
+        Profile existing = new Profile();
+        existing.setId(profileId);
+        existing.setEmail("old@mail.com");
+        existing.setPassword(PasswordHasher.hashPwd("123456"));
+
+        when(dao.findById(profileId)).thenReturn(Optional.of(existing));
+        when(dao.existsEmail("new@mail.com", profileId)).thenReturn(true);
+
+        DuplicateEmailException ex = assertThrows(
+                DuplicateEmailException.class,
+                () -> service.changeEmail(profileId, dto)
+        );
+
+        assertEquals("error.email.exists", ex.getMessage());
+        verify(dao).findById(profileId);
+        verify(dao).existsEmail("new@mail.com", profileId);
+        verify(dao, never()).update(any());
+    }
+}

--- a/back/src/test/java/ru/andrewb/charm/back/service/ProfileServiceChangePasswordTest.java
+++ b/back/src/test/java/ru/andrewb/charm/back/service/ProfileServiceChangePasswordTest.java
@@ -1,0 +1,234 @@
+package ru.andrewb.charm.back.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import ru.andrewb.charm.back.dao.ProfileDao;
+import ru.andrewb.charm.back.dto.PasswordChangeDto;
+import ru.andrewb.charm.back.mapper.ProfileToProfileGetDtoMapper;
+import ru.andrewb.charm.back.mapper.ProfileToUserDetailsDtoMapper;
+import ru.andrewb.charm.back.mapper.ProfileUpdateDtoToProfileMapper;
+import ru.andrewb.charm.back.model.Profile;
+import ru.andrewb.charm.back.model.exception.BadRequestException;
+import ru.andrewb.charm.back.model.exception.NotFoundException;
+import ru.andrewb.charm.back.security.PasswordHasher;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ProfileServiceChangePasswordTest {
+
+    @Mock
+    private ProfileDao dao;
+
+    @Mock
+    private ContentService contentService;
+
+    @Mock
+    private ProfileToProfileGetDtoMapper profileToProfileGetDtoMapper;
+
+    @Mock
+    private ProfileUpdateDtoToProfileMapper profileUpdateDtoToProfileMapper;
+
+    @Mock
+    private ProfileToUserDetailsDtoMapper profileToUserDetailsDtoMapper;
+
+    private ProfileService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new ProfileService(
+                dao,
+                contentService,
+                profileToProfileGetDtoMapper,
+                profileUpdateDtoToProfileMapper,
+                profileToUserDetailsDtoMapper
+        );
+    }
+
+    @Test
+    void changePassword_shouldUpdatePassword_whenInputIsValid() {
+        long profileId = 1L;
+
+        PasswordChangeDto dto = new PasswordChangeDto();
+        dto.setVersion(4);
+        dto.setCurrentPassword("oldpass");
+        dto.setNewPassword("newpass");
+        dto.setConfirmPassword("newpass");
+
+        Profile profile = new Profile();
+        profile.setId(profileId);
+        profile.setVersion(1);
+        profile.setEmail("user@mail.com");
+        profile.setPassword(PasswordHasher.hashPwd("oldpass"));
+
+        when(dao.findById(profileId)).thenReturn(Optional.of(profile));
+
+        String oldHash = profile.getPassword();
+
+        service.changePassword(profileId, dto);
+
+        assertEquals(4, profile.getVersion());
+        assertNotEquals(oldHash, profile.getPassword());
+        assertTrue(PasswordHasher.checkPwd("newpass", profile.getPassword()));
+        verify(dao).findById(profileId);
+        verify(dao).update(profile);
+    }
+
+    @Test
+    void changePassword_shouldThrowNotFoundException_whenProfileDoesNotExist() {
+        long profileId = 1L;
+
+        PasswordChangeDto dto = new PasswordChangeDto();
+        dto.setVersion(1);
+        dto.setCurrentPassword("oldpass");
+        dto.setNewPassword("newpass");
+        dto.setConfirmPassword("newpass");
+
+        when(dao.findById(profileId)).thenReturn(Optional.empty());
+
+        NotFoundException ex = assertThrows(
+                NotFoundException.class,
+                () -> service.changePassword(profileId, dto)
+        );
+
+        assertEquals("error.profile.not-found", ex.getMessage());
+        verify(dao).findById(profileId);
+        verify(dao, never()).update(any());
+    }
+
+    @Test
+    void changePassword_shouldThrowBadRequestException_whenVersionIsMissing() {
+        long profileId = 1L;
+
+        PasswordChangeDto dto = new PasswordChangeDto();
+        dto.setVersion(null);
+        dto.setCurrentPassword("oldpass");
+        dto.setNewPassword("newpass");
+        dto.setConfirmPassword("newpass");
+
+        Profile profile = new Profile();
+        profile.setId(profileId);
+        profile.setPassword(PasswordHasher.hashPwd("oldpass"));
+
+        when(dao.findById(profileId)).thenReturn(Optional.of(profile));
+
+        BadRequestException ex = assertThrows(
+                BadRequestException.class,
+                () -> service.changePassword(profileId, dto)
+        );
+
+        assertEquals("error.param.required", ex.getMessage());
+        verify(dao).findById(profileId);
+        verify(dao, never()).update(any());
+    }
+
+    @Test
+    void changePassword_shouldThrowBadRequestException_whenConfirmPasswordIsBlank() {
+        long profileId = 1L;
+
+        PasswordChangeDto dto = new PasswordChangeDto();
+        dto.setVersion(1);
+        dto.setCurrentPassword("oldpass");
+        dto.setNewPassword("newpass");
+        dto.setConfirmPassword("   ");
+
+        Profile profile = new Profile();
+        profile.setId(profileId);
+        profile.setPassword(PasswordHasher.hashPwd("oldpass"));
+
+        when(dao.findById(profileId)).thenReturn(Optional.of(profile));
+
+        BadRequestException ex = assertThrows(
+                BadRequestException.class,
+                () -> service.changePassword(profileId, dto)
+        );
+
+        assertEquals("error.password.required", ex.getMessage());
+        verify(dao).findById(profileId);
+        verify(dao, never()).update(any());
+    }
+
+    @Test
+    void changePassword_shouldThrowBadRequestException_whenConfirmPasswordDoesNotMatch() {
+        long profileId = 1L;
+
+        PasswordChangeDto dto = new PasswordChangeDto();
+        dto.setVersion(1);
+        dto.setCurrentPassword("oldpass");
+        dto.setNewPassword("newpass");
+        dto.setConfirmPassword("otherpass");
+
+        Profile existing = new Profile();
+        existing.setId(profileId);
+        existing.setPassword(PasswordHasher.hashPwd("oldpass"));
+
+        when(dao.findById(profileId)).thenReturn(Optional.of(existing));
+
+        BadRequestException ex = assertThrows(
+                BadRequestException.class,
+                () -> service.changePassword(profileId, dto)
+        );
+
+        assertEquals("error.password.mismatch", ex.getMessage());
+        verify(dao).findById(profileId);
+        verify(dao, never()).update(any());
+    }
+
+    @Test
+    void changePassword_shouldThrowBadRequestException_whenCurrentPasswordIsIncorrect() {
+        long profileId = 1L;
+
+        PasswordChangeDto dto = new PasswordChangeDto();
+        dto.setVersion(1);
+        dto.setCurrentPassword("wrongpass");
+        dto.setNewPassword("newpass");
+        dto.setConfirmPassword("newpass");
+
+        Profile profile = new Profile();
+        profile.setId(profileId);
+        profile.setPassword(PasswordHasher.hashPwd("oldpass"));
+
+        when(dao.findById(profileId)).thenReturn(Optional.of(profile));
+
+        BadRequestException ex = assertThrows(
+                BadRequestException.class,
+                () -> service.changePassword(profileId, dto)
+        );
+
+        assertEquals("error.password.invalid-current", ex.getMessage());
+        verify(dao).findById(profileId);
+        verify(dao, never()).update(any());
+    }
+
+    @Test
+    void changePassword_shouldThrowBadRequestException_whenNewPasswordMatchesCurrentPassword() {
+        long profileId = 1L;
+
+        PasswordChangeDto dto = new PasswordChangeDto();
+        dto.setVersion(1);
+        dto.setCurrentPassword("samepass");
+        dto.setNewPassword("samepass");
+        dto.setConfirmPassword("samepass");
+
+        Profile profile = new Profile();
+        profile.setId(profileId);
+        profile.setPassword(PasswordHasher.hashPwd("samepass"));
+
+        when(dao.findById(profileId)).thenReturn(Optional.of(profile));
+
+        BadRequestException ex = assertThrows(
+                BadRequestException.class,
+                () -> service.changePassword(profileId, dto)
+        );
+
+        assertEquals("error.password.same-as-current", ex.getMessage());
+        verify(dao).findById(profileId);
+        verify(dao, never()).update(any());
+    }
+}

--- a/back/src/test/java/ru/andrewb/charm/back/service/ProfileServiceLoginTest.java
+++ b/back/src/test/java/ru/andrewb/charm/back/service/ProfileServiceLoginTest.java
@@ -1,0 +1,144 @@
+package ru.andrewb.charm.back.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import ru.andrewb.charm.back.dao.ProfileDao;
+import ru.andrewb.charm.back.dto.LoginDto;
+import ru.andrewb.charm.back.dto.UserDetailsDto;
+import ru.andrewb.charm.back.mapper.ProfileToProfileGetDtoMapper;
+import ru.andrewb.charm.back.mapper.ProfileToUserDetailsDtoMapper;
+import ru.andrewb.charm.back.mapper.ProfileUpdateDtoToProfileMapper;
+import ru.andrewb.charm.back.model.Profile;
+import ru.andrewb.charm.back.model.Role;
+import ru.andrewb.charm.back.model.exception.BadRequestException;
+import ru.andrewb.charm.back.security.PasswordHasher;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ProfileServiceLoginTest {
+
+    @Mock
+    private ProfileDao dao;
+
+    @Mock
+    private ContentService contentService;
+
+    @Mock
+    private ProfileToProfileGetDtoMapper profileToProfileGetDtoMapper;
+
+    @Mock
+    private ProfileUpdateDtoToProfileMapper profileUpdateDtoToProfileMapper;
+
+    @Mock
+    private ProfileToUserDetailsDtoMapper profileToUserDetailsDtoMapper;
+
+    private ProfileService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new ProfileService(
+                dao,
+                contentService,
+                profileToProfileGetDtoMapper,
+                profileUpdateDtoToProfileMapper,
+                profileToUserDetailsDtoMapper
+        );
+    }
+
+    @Test
+    void login_shouldReturnUserDetails_whenCredentialsAreCorrect() {
+        LoginDto dto = new LoginDto();
+        dto.setEmail("user@mail.com");
+        dto.setPassword("123456");
+
+        Profile profile = new Profile();
+        profile.setId(1L);
+        profile.setEmail("user@mail.com");
+        profile.setPassword(PasswordHasher.hashPwd("123456"));
+        profile.setRole(Role.USER);
+
+        UserDetailsDto expected = new UserDetailsDto();
+        expected.setId(1L);
+        expected.setEmail("user@mail.com");
+        expected.setRole(Role.USER);
+
+        when(dao.findByEmail("user@mail.com")).thenReturn(Optional.of(profile));
+        when(profileToUserDetailsDtoMapper.map(profile)).thenReturn(expected);
+
+        UserDetailsDto result = service.login(dto);
+
+        assertSame(expected, result);
+        verify(dao).findByEmail("user@mail.com");
+        verify(profileToUserDetailsDtoMapper).map(profile);
+    }
+
+    @Test
+    void login_shouldThrowBadRequestException_whenUserIsNotFound() {
+        LoginDto dto = new LoginDto();
+        dto.setEmail("missing@mail.com");
+        dto.setPassword("123456");
+
+        when(dao.findByEmail("missing@mail.com")).thenReturn(Optional.empty());
+
+        BadRequestException ex = assertThrows(
+                BadRequestException.class,
+                () -> service.login(dto)
+        );
+
+        assertEquals("error.login.bad-credentials",  ex.getMessage());
+        verify(dao).findByEmail("missing@mail.com");
+    }
+
+    @Test
+    void login_shouldThrowBadRequestException_whenPasswordIsIncorrect() {
+        LoginDto dto = new LoginDto();
+        dto.setEmail("user@mail.com");
+        dto.setPassword("wrong-password");
+
+        Profile profile = new Profile();
+        profile.setEmail("user@mail.com");
+        profile.setPassword(PasswordHasher.hashPwd("correct-password"));
+
+        when(dao.findByEmail("user@mail.com")).thenReturn(Optional.of(profile));
+
+        BadRequestException ex = assertThrows(
+                BadRequestException.class,
+                () -> service.login(dto)
+        );
+
+        assertEquals("error.login.bad-credentials",  ex.getMessage());
+        verify(dao).findByEmail("user@mail.com");
+    }
+
+    @Test
+    void login_shouldTrimEmail_beforeSearchingUser() {
+        LoginDto dto = new LoginDto();
+        dto.setEmail("   user@mail.com   ");
+        dto.setPassword("123456");
+
+        Profile profile = new Profile();
+        profile.setId(1L);
+        profile.setEmail("user@mail.com");
+        profile.setPassword(PasswordHasher.hashPwd("123456"));
+
+        UserDetailsDto expected = new UserDetailsDto();
+        expected.setId(1L);
+        expected.setEmail("user@mail.com");
+
+        when(dao.findByEmail("user@mail.com")).thenReturn(Optional.of(profile));
+        when(profileToUserDetailsDtoMapper.map(profile)).thenReturn(expected);
+
+        UserDetailsDto result = service.login(dto);
+
+        assertSame(expected, result);
+        verify(dao).findByEmail("user@mail.com");
+    }
+}

--- a/back/src/test/java/ru/andrewb/charm/back/validator/EmailChangeValidatorTest.java
+++ b/back/src/test/java/ru/andrewb/charm/back/validator/EmailChangeValidatorTest.java
@@ -1,0 +1,119 @@
+package ru.andrewb.charm.back.validator;
+
+import org.junit.jupiter.api.Test;
+import ru.andrewb.charm.back.dto.EmailChangeDto;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class EmailChangeValidatorTest {
+
+    private final EmailChangeValidator validator = EmailChangeValidator.getInstance();
+
+    @Test
+    void validate_shouldReturnError_whenDtoIsNull() {
+        ValidationResult result = validator.validate(null);
+
+        assertTrue(result.isNotValid());
+        assertEquals(List.of("error.dto.required"), result.getErrors());
+    }
+
+    @Test
+    void validate_shouldReturnValidResult_forCorrectDto() {
+        EmailChangeDto dto = new EmailChangeDto();
+        dto.setNewEmail("user@mail.com");
+        dto.setCurrentPassword("123456");
+
+        ValidationResult result = validator.validate(dto);
+
+        assertFalse(result.isNotValid());
+        assertEquals(List.of(), result.getErrors());
+    }
+
+    @Test
+    void validate_shouldReturnError_whenNewEmailIsNull() {
+        EmailChangeDto dto = new EmailChangeDto();
+        dto.setNewEmail(null);
+        dto.setCurrentPassword("123456");
+
+        ValidationResult result = validator.validate(dto);
+
+        assertTrue(result.isNotValid());
+        assertEquals(List.of("error.email.required"), result.getErrors());
+    }
+
+    @Test
+    void validate_shouldReturnError_whenNewEmailIsBlank() {
+        EmailChangeDto dto = new EmailChangeDto();
+        dto.setNewEmail("   ");
+        dto.setCurrentPassword("123456");
+
+        ValidationResult result = validator.validate(dto);
+
+        assertTrue(result.isNotValid());
+        assertEquals(List.of("error.email.required"), result.getErrors());
+    }
+
+    @Test
+    void validate_shouldReturnError_whenNewEmailHasInvalidFormat() {
+        EmailChangeDto dto = new EmailChangeDto();
+        dto.setNewEmail("invalid");
+        dto.setCurrentPassword("123456");
+
+        ValidationResult result = validator.validate(dto);
+
+        assertTrue(result.isNotValid());
+        assertEquals(List.of("error.email.invalid"), result.getErrors());
+    }
+
+    @Test
+    void validate_shouldReturnError_whenCurrentPasswordIsNull() {
+        EmailChangeDto dto = new EmailChangeDto();
+        dto.setNewEmail("user@mail.com");
+        dto.setCurrentPassword(null);
+
+        ValidationResult result = validator.validate(dto);
+
+        assertTrue(result.isNotValid());
+        assertEquals(List.of("error.password.current-required"), result.getErrors());
+    }
+
+    @Test
+    void validate_shouldReturnError_whenCurrentPasswordIsBlank() {
+        EmailChangeDto dto = new EmailChangeDto();
+        dto.setNewEmail("user@mail.com");
+        dto.setCurrentPassword("   ");
+
+        ValidationResult result = validator.validate(dto);
+
+        assertTrue(result.isNotValid());
+        assertEquals(List.of("error.password.current-required"), result.getErrors());
+    }
+
+    @Test
+    void validate_shouldReturnBothErrors_whenEmailAndPasswordAreInvalid() {
+        EmailChangeDto dto = new EmailChangeDto();
+        dto.setNewEmail("invalid");
+        dto.setCurrentPassword("   ");
+
+        ValidationResult result = validator.validate(dto);
+
+        assertTrue(result.isNotValid());
+        assertEquals(
+                List.of("error.email.invalid", "error.password.current-required"),
+                result.getErrors()
+        );
+    }
+
+    @Test
+    void validate_shouldAcceptTrimmedValues() {
+        EmailChangeDto dto = new EmailChangeDto();
+        dto.setNewEmail("  user@mail.com  ");
+        dto.setCurrentPassword("  123456  ");
+
+        ValidationResult result = validator.validate(dto);
+
+        assertFalse(result.isNotValid());
+    }
+}

--- a/back/src/test/java/ru/andrewb/charm/back/validator/EmailUtilsTest.java
+++ b/back/src/test/java/ru/andrewb/charm/back/validator/EmailUtilsTest.java
@@ -1,0 +1,101 @@
+package ru.andrewb.charm.back.validator;
+
+import org.junit.jupiter.api.Test;
+import ru.andrewb.charm.back.model.exception.BadRequestException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class EmailUtilsTest {
+
+    @Test
+    void normalize_shouldReturnNull_forNull() {
+        assertNull(EmailUtils.normalize(null));
+    }
+
+    @Test
+    void normalize_shouldTrimValue() {
+        assertEquals("user@mail.com", EmailUtils.normalize("  user@mail.com  "));
+    }
+
+    @Test
+    void hasText_shouldReturnFalse_forNull() {
+        assertFalse(EmailUtils.hasText(null));
+    }
+
+    @Test
+    void hasText_shouldReturnFalse_forEmptyString() {
+        assertFalse(EmailUtils.hasText(""));
+    }
+
+    @Test
+    void hasText_shouldReturnFalse_forBlankString() {
+        assertFalse(EmailUtils.hasText("   "));
+    }
+
+    @Test
+    void hasText_shouldReturnTrue_forNonBlankString() {
+        assertTrue(EmailUtils.hasText("user@mail.com"));
+    }
+
+    @Test
+    void matchesFormat_shouldReturnTrue_forValidEmail() {
+        assertTrue(EmailUtils.matchesFormat("user@mail.com"));
+    }
+
+    @Test
+    void matchesFormat_shouldReturnTrue_forUppercaseEmail() {
+        assertTrue(EmailUtils.matchesFormat("USER@MAIL.COM"));
+    }
+
+    @Test
+    void matchesFormat_shouldReturnTrue_forEmailWithPlus() {
+        assertTrue(EmailUtils.matchesFormat("user+tag@mail.com"));
+    }
+
+    @Test
+    void matchesFormat_shouldReturnFalse_forNull() {
+        assertFalse(EmailUtils.matchesFormat(null));
+    }
+
+    @Test
+    void matchesFormat_shouldReturnFalse_whenMissingAtSign() {
+        assertFalse(EmailUtils.matchesFormat("usermail.com"));
+    }
+
+    @Test
+    void matchesFormat_shouldReturnFalse_whenMissingDomain() {
+        assertFalse(EmailUtils.matchesFormat("user@"));
+    }
+
+    @Test
+    void requireValidOrThrow_shouldThrow_whenEmailIsNull() {
+        BadRequestException ex = assertThrows(
+                BadRequestException.class,
+                () -> EmailUtils.requireValidOrThrow(null)
+        );
+
+        assertEquals("error.email.required", ex.getMessage());
+    }
+
+    @Test
+    void requireValidOrThrow_shouldThrow_whenEmailIsBlank() {
+        BadRequestException ex = assertThrows(
+                BadRequestException.class,
+                () -> EmailUtils.requireValidOrThrow("   ")
+        );
+
+        assertEquals("error.email.required", ex.getMessage());
+    }
+
+    @Test
+    void requireValidOrThrow_shouldThrow_whenEmailHasInvalidFormat() {
+        BadRequestException ex = assertThrows(
+                BadRequestException.class,
+                () -> EmailUtils.requireValidOrThrow("invalid")
+        );
+
+        assertEquals("error.email.invalid", ex.getMessage());
+    }
+
+
+}

--- a/back/src/test/java/ru/andrewb/charm/back/validator/LoginValidatorTest.java
+++ b/back/src/test/java/ru/andrewb/charm/back/validator/LoginValidatorTest.java
@@ -1,0 +1,120 @@
+package ru.andrewb.charm.back.validator;
+
+import org.junit.jupiter.api.Test;
+import ru.andrewb.charm.back.dto.LoginDto;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class LoginValidatorTest {
+
+    private final LoginValidator validator = LoginValidator.getInstance();
+
+    @Test
+    void validate_shouldReturnError_whenDtoIsNull() {
+        ValidationResult result = validator.validate(null);
+
+        assertTrue(result.isNotValid());
+        assertEquals(List.of("error.dto.required"), result.getErrors());
+    }
+
+    @Test
+    void validate_shouldReturnValidResult_forCorrectDto() {
+        LoginDto dto = new LoginDto();
+        dto.setEmail("user@mail.ru");
+        dto.setPassword("123456");
+
+        ValidationResult result = validator.validate(dto);
+
+        assertFalse(result.isNotValid());
+        assertEquals(List.of(), result.getErrors());
+    }
+
+    @Test
+    void validate_shouldReturnError_whenEmailIsNull() {
+        LoginDto dto = new LoginDto();
+        dto.setEmail(null);
+        dto.setPassword("123456");
+
+        ValidationResult result = validator.validate(dto);
+
+        assertTrue(result.isNotValid());
+        assertEquals(List.of("error.email.required"), result.getErrors());
+    }
+
+    @Test
+    void validate_shouldReturnError_whenEmailIsBlank() {
+        LoginDto dto = new LoginDto();
+        dto.setEmail("   ");
+        dto.setPassword("123456");
+
+        ValidationResult result = validator.validate(dto);
+
+        assertTrue(result.isNotValid());
+        assertEquals(List.of("error.email.required"), result.getErrors());
+    }
+
+    @Test
+    void validate_shouldReturnError_whenEmailHasInvalidFormat() {
+        LoginDto dto = new LoginDto();
+        dto.setEmail("invalid");
+        dto.setPassword("123456");
+
+        ValidationResult result = validator.validate(dto);
+
+        assertTrue(result.isNotValid());
+        assertEquals(List.of("error.email.invalid"), result.getErrors());
+    }
+
+    @Test
+    void validate_shouldReturnError_whenPasswordIsNull() {
+        LoginDto dto = new LoginDto();
+        dto.setEmail("user@mail.ru");
+        dto.setPassword(null);
+
+        ValidationResult result = validator.validate(dto);
+
+        assertTrue(result.isNotValid());
+        assertEquals(List.of("error.password.required"), result.getErrors());
+    }
+
+    @Test
+    void validate_shouldReturnError_whenPasswordIsBlank() {
+        LoginDto dto = new LoginDto();
+        dto.setEmail("user@mail.ru");
+        dto.setPassword("   ");
+
+        ValidationResult result = validator.validate(dto);
+
+        assertTrue(result.isNotValid());
+        assertEquals(List.of("error.password.required"), result.getErrors());
+    }
+
+    @Test
+    void validate_shouldReturnBothErrors_wherEmailAndPasswordAreInvalid() {
+        LoginDto dto = new LoginDto();
+        dto.setEmail("invalid");
+        dto.setPassword("   ");
+
+        ValidationResult result = validator.validate(dto);
+
+        assertTrue(result.isNotValid());
+        assertEquals(
+                List.of("error.email.invalid", "error.password.required"),
+                result.getErrors()
+        );
+    }
+
+    @Test
+    void validate_shouldAcceptTrimmedEmailAndPassword() {
+        LoginDto dto = new LoginDto();
+        dto.setEmail("   user@mail.ru   ");
+        dto.setPassword("   123456   ");
+
+        ValidationResult result = validator.validate(dto);
+
+        assertFalse(result.isNotValid());
+    }
+
+}

--- a/back/src/test/java/ru/andrewb/charm/back/validator/PasswordChangeValidatorTest.java
+++ b/back/src/test/java/ru/andrewb/charm/back/validator/PasswordChangeValidatorTest.java
@@ -1,0 +1,137 @@
+package ru.andrewb.charm.back.validator;
+
+import org.junit.jupiter.api.Test;
+import ru.andrewb.charm.back.dto.PasswordChangeDto;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PasswordChangeValidatorTest {
+
+    private final PasswordChangeValidator validator = PasswordChangeValidator.getInstance();
+
+    @Test
+    void validate_shouldReturnError_whenDtoIsNull() {
+        ValidationResult result = validator.validate(null);
+
+        assertTrue(result.isNotValid());
+        assertEquals(List.of("error.dto.required"), result.getErrors());
+    }
+
+    @Test
+    void validate_shouldReturnValidResult_forCorrectDto() {
+        PasswordChangeDto dto = new PasswordChangeDto();
+        dto.setCurrentPassword("oldpass");
+        dto.setNewPassword("newpass");
+        dto.setConfirmPassword("newpass");
+
+        ValidationResult result = validator.validate(dto);
+
+        assertFalse(result.isNotValid());
+        assertEquals(List.of(), result.getErrors());
+    }
+
+    @Test
+    void validate_shouldReturnError_whenCurrentPasswordIsMissing() {
+        PasswordChangeDto dto = new PasswordChangeDto();
+        dto.setCurrentPassword("   ");
+        dto.setNewPassword("newpass");
+        dto.setConfirmPassword("newpass");
+
+        ValidationResult result = validator.validate(dto);
+
+        assertTrue(result.isNotValid());
+        assertEquals(List.of("error.password.current-required"), result.getErrors());
+    }
+
+    @Test
+    void validate_shouldReturnBothErrors_whenNewPasswordIsMissing() {
+        PasswordChangeDto dto = new PasswordChangeDto();
+        dto.setCurrentPassword("oldpass");
+        dto.setNewPassword("   ");
+        dto.setConfirmPassword("newpass");
+
+        ValidationResult result = validator.validate(dto);
+
+        assertTrue(result.isNotValid());
+        assertEquals(
+                List.of(
+                        "error.password.new-required",
+                        "error.password.mismatch"
+                ),
+                result.getErrors()
+        );
+    }
+
+    @Test
+    void validate_shouldReturnError_whenNewPasswordIsTooShort() {
+        PasswordChangeDto dto = new PasswordChangeDto();
+        dto.setCurrentPassword("oldpass");
+        dto.setNewPassword("123");
+        dto.setConfirmPassword("123");
+
+        ValidationResult result = validator.validate(dto);
+
+        assertTrue(result.isNotValid());
+        assertEquals(List.of("error.password.short"), result.getErrors());
+    }
+
+    @Test
+    void validate_shouldReturnError_whenConfirmPasswordIsMissing() {
+        PasswordChangeDto dto = new PasswordChangeDto();
+        dto.setCurrentPassword("oldpass");
+        dto.setNewPassword("newpass");
+        dto.setConfirmPassword("   ");
+
+        ValidationResult result = validator.validate(dto);
+
+        assertTrue(result.isNotValid());
+        assertEquals(List.of("error.password.confirm-required"), result.getErrors());
+    }
+
+    @Test
+    void validate_shouldReturnError_whenConfirmPasswordDoesNotMatch() {
+        PasswordChangeDto dto = new PasswordChangeDto();
+        dto.setCurrentPassword("oldpass");
+        dto.setNewPassword("newpass");
+        dto.setConfirmPassword("otherpass");
+
+        ValidationResult result = validator.validate(dto);
+
+        assertTrue(result.isNotValid());
+        assertEquals(List.of("error.password.mismatch"), result.getErrors());
+    }
+
+    @Test
+    void validate_shouldReturnMultipleErrors_whenSeveralFieldsAreInvalid() {
+        PasswordChangeDto dto = new PasswordChangeDto();
+        dto.setCurrentPassword("   ");
+        dto.setNewPassword("123");
+        dto.setConfirmPassword("456");
+
+        ValidationResult result = validator.validate(dto);
+
+        assertTrue(result.isNotValid());
+        assertEquals(
+                List.of(
+                        "error.password.current-required",
+                        "error.password.short",
+                        "error.password.mismatch"
+                ),
+                result.getErrors()
+        );
+    }
+
+    @Test
+    void validate_shouldAcceptTrimmedValues() {
+        PasswordChangeDto dto = new PasswordChangeDto();
+        dto.setCurrentPassword("  oldpass  ");
+        dto.setNewPassword(  "newpass"  );
+        dto.setConfirmPassword("  newpass  ");
+
+        ValidationResult result = validator.validate(dto);
+
+        assertFalse(result.isNotValid());
+    }
+}

--- a/back/src/test/java/ru/andrewb/charm/back/validator/PasswordUtilsTest.java
+++ b/back/src/test/java/ru/andrewb/charm/back/validator/PasswordUtilsTest.java
@@ -1,0 +1,86 @@
+package ru.andrewb.charm.back.validator;
+
+import org.junit.jupiter.api.Test;
+import ru.andrewb.charm.back.model.exception.BadRequestException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PasswordUtilsTest {
+
+    @Test
+    void normalize_shouldReturnNull_forNull() {
+        assertNull(PasswordUtils.normalize(null));
+    }
+
+    @Test
+    void normalize_shouldTrimValue() {
+        assertEquals("password", PasswordUtils.normalize("  password  "));
+    }
+
+    @Test
+    void hasText_shouldReturnFalse_forNull() {
+        assertFalse(PasswordUtils.hasText(null));
+    }
+
+    @Test
+    void hasText_shouldReturnFalse_forEmptyString() {
+        assertFalse(PasswordUtils.hasText(""));
+    }
+
+    @Test
+    void hasText_shouldReturnFalse_forBlankString() {
+        assertFalse(PasswordUtils.hasText("   "));
+    }
+
+    @Test
+    void hasText_shouldReturnTrue_forNotBlankString() {
+        assertTrue(PasswordUtils.hasText("password"));
+    }
+
+    @Test
+    void lengthAtLeast_shouldReturnFalse_forNull() {
+        assertFalse(PasswordUtils.lengthAtLeast(null, 6));
+    }
+
+    @Test
+    void lengthAtLeast_shouldReturnFalse_whenPasswordIsShorterThenMinLength() {
+        assertFalse(PasswordUtils.lengthAtLeast("12345", 6));
+    }
+
+    @Test
+    void lengthAtLeast_shouldReturnTrue_whenPasswordMatchesMinLength() {
+        assertTrue(PasswordUtils.lengthAtLeast("123456", 6));
+    }
+
+    @Test
+    void lengthAtLeast_shouldReturnTrue_whenPasswordIsLongerThenMinLength() {
+        assertTrue(PasswordUtils.lengthAtLeast("123456789", 6));
+    }
+
+    @Test
+    void requireValidOrThrow_shouldReturnNormalizesPassword_forValidValue() {
+        String result = PasswordUtils.requireValidOrThrow("  password123   ", 6);
+
+        assertEquals("password123", result);
+    }
+
+    @Test
+    void requireValidOrThrow_shouldThrow_whenPasswordIsBlank() {
+        BadRequestException ex = assertThrows(
+                BadRequestException.class,
+                () -> PasswordUtils.requireValidOrThrow("  ", 6)
+        );
+
+        assertEquals("error.password.required",  ex.getMessage());
+    }
+
+    @Test
+    void requireValidOrThrow_shouldThrow_whenPasswordIsTooShort() {
+        BadRequestException ex = assertThrows(
+                BadRequestException.class,
+                () -> PasswordUtils.requireValidOrThrow("12345", 6)
+        );
+
+        assertEquals("error.password.short",  ex.getMessage());
+    }
+}

--- a/back/src/test/java/ru/andrewb/charm/back/validator/ProfileUpdateValidatorTest.java
+++ b/back/src/test/java/ru/andrewb/charm/back/validator/ProfileUpdateValidatorTest.java
@@ -1,0 +1,128 @@
+package ru.andrewb.charm.back.validator;
+
+import org.junit.jupiter.api.Test;
+import ru.andrewb.charm.back.dto.ProfileUpdateDto;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ProfileUpdateValidatorTest {
+
+    private final ProfileUpdateValidator validator = ProfileUpdateValidator.getInstance();
+
+    @Test
+    void validate_shouldReturnError_whenDtoIsNull() {
+        ValidationResult result = validator.validate(null);
+
+        assertTrue(result.isNotValid());
+        assertEquals(List.of("error.dto.required"), result.getErrors());
+    }
+
+    @Test
+    void validate_shouldReturnValidResult_forCorrectDto() {
+        ProfileUpdateDto dto = new ProfileUpdateDto();
+        dto.setName("Ivan");
+        dto.setSurname("Ivanov");
+        dto.setAbout("About me");
+        dto.setBirthdate(LocalDate.now().minusYears(20));
+
+        ValidationResult result = validator.validate(dto);
+
+        assertFalse(result.isNotValid());
+        assertEquals(List.of(), result.getErrors());
+    }
+
+    @Test
+    void validate_shouldReturnError_whenNameIsTooLong() {
+        ProfileUpdateDto dto = new ProfileUpdateDto();
+        dto.setName("a".repeat(101));
+
+        ValidationResult result = validator.validate(dto);
+
+        assertTrue(result.isNotValid());
+        assertEquals(List.of("error.name.too-long"), result.getErrors());
+    }
+
+    @Test
+    void validate_shouldReturnError_whenSurnameIsTooLong() {
+        ProfileUpdateDto dto = new ProfileUpdateDto();
+        dto.setSurname("a".repeat(101));
+
+        ValidationResult result = validator.validate(dto);
+
+        assertTrue(result.isNotValid());
+        assertEquals(List.of("error.surname.too-long"), result.getErrors());
+    }
+
+    @Test
+    void validate_shouldReturnError_whenAboutIsTooLong() {
+        ProfileUpdateDto dto = new ProfileUpdateDto();
+        dto.setAbout("a".repeat(1001));
+
+        ValidationResult result = validator.validate(dto);
+
+        assertTrue(result.isNotValid());
+        assertEquals(List.of("error.about.too-long"), result.getErrors());
+    }
+
+    @Test
+    void validate_shouldReturnError_whenBirthdateIsInFuture() {
+        ProfileUpdateDto dto = new ProfileUpdateDto();
+        dto.setBirthdate(LocalDate.now().plusDays(1));
+
+        ValidationResult result = validator.validate(dto);
+
+        assertTrue(result.isNotValid());
+        assertEquals(
+                List.of(
+                        "error.birthdate.future",
+                        "error.birthdate.underage"
+                ),
+                result.getErrors()
+        );
+    }
+
+    @Test
+    void validate_shouldReturnError_whenBirthdateIsTooOld() {
+        ProfileUpdateDto dto = new ProfileUpdateDto();
+        dto.setBirthdate(LocalDate.of(1899, 12, 31));
+
+        ValidationResult result = validator.validate(dto);
+
+        assertTrue(result.isNotValid());
+        assertEquals(List.of("error.birthdate.too-old"), result.getErrors());
+    }
+
+    @Test
+    void validate_shouldReturnError_whenUserIsUnderage() {
+        ProfileUpdateDto dto = new ProfileUpdateDto();
+        dto.setBirthdate(LocalDate.now().minusYears(17));
+
+        ValidationResult result = validator.validate(dto);
+
+        assertTrue(result.isNotValid());
+        assertEquals(List.of("error.birthdate.underage"), result.getErrors());
+    }
+
+    @Test
+    void validate_shouldReturnMultipleErrors_whenSeveralFieldsAreInvalid() {
+        ProfileUpdateDto dto = new ProfileUpdateDto();
+        dto.setName("a".repeat(101));
+        dto.setSurname("b".repeat(101));
+        dto.setAbout("c".repeat(1001));
+
+        ValidationResult result = validator.validate(dto);
+
+        assertTrue(result.isNotValid());
+        assertEquals(
+                List.of(
+                        "error.name.too-long",
+                        "error.surname.too-long",
+                        "error.about.too-long"
+                ),
+                result.getErrors()
+        );
+    }
+}

--- a/back/src/test/java/ru/andrewb/charm/back/validator/RegistrationValidatorTest.java
+++ b/back/src/test/java/ru/andrewb/charm/back/validator/RegistrationValidatorTest.java
@@ -1,0 +1,131 @@
+package ru.andrewb.charm.back.validator;
+
+import org.junit.jupiter.api.Test;
+import ru.andrewb.charm.back.dto.RegistrationDto;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class RegistrationValidatorTest {
+
+    private final RegistrationValidator validator = RegistrationValidator.getInstance();
+
+    @Test
+    void validate_shouldReturnError_whenDtoIsNull() {
+        ValidationResult result = validator.validate(null);
+
+        assertTrue(result.isNotValid());
+        assertEquals(List.of("error.dto.required"), result.getErrors());
+    }
+
+    @Test
+    void validate_shouldReturnValidResult_forCorrectDto() {
+        RegistrationDto dto = new RegistrationDto();
+        dto.setEmail("user@mail.ru");
+        dto.setPassword("123456");
+
+        ValidationResult result = validator.validate(dto);
+
+        assertFalse(result.isNotValid());
+        assertEquals(List.of(), result.getErrors());
+    }
+
+    @Test
+    void validate_shouldReturnError_whenEmailIsNull() {
+        RegistrationDto dto = new RegistrationDto();
+        dto.setEmail(null);
+        dto.setPassword("123456");
+
+        ValidationResult result = validator.validate(dto);
+
+        assertTrue(result.isNotValid());
+        assertEquals(List.of("error.email.required"), result.getErrors());
+    }
+
+    @Test
+    void validate_shouldReturnError_whenEmailIsBlank() {
+        RegistrationDto dto = new RegistrationDto();
+        dto.setEmail("   ");
+        dto.setPassword("123456");
+
+        ValidationResult result = validator.validate(dto);
+
+        assertTrue(result.isNotValid());
+        assertEquals(List.of("error.email.required"), result.getErrors());
+    }
+
+    @Test
+    void validate_shouldReturnError_whenEmailHasInvalidFormat() {
+        RegistrationDto dto = new RegistrationDto();
+        dto.setEmail("invalid");
+        dto.setPassword("123456");
+
+        ValidationResult result = validator.validate(dto);
+
+        assertTrue(result.isNotValid());
+        assertEquals(List.of("error.email.invalid"), result.getErrors());
+    }
+
+    @Test
+    void validate_shouldReturnError_whenPasswordIsNull() {
+        RegistrationDto dto = new RegistrationDto();
+        dto.setEmail("user@mail.ru");
+        dto.setPassword(null);
+
+        ValidationResult result = validator.validate(dto);
+
+        assertTrue(result.isNotValid());
+        assertEquals(List.of("error.password.required"), result.getErrors());
+    }
+
+    @Test
+    void validate_shouldReturnError_whenPasswordIsBlank() {
+        RegistrationDto dto = new RegistrationDto();
+        dto.setEmail("user@mail.ru");
+        dto.setPassword("   ");
+
+        ValidationResult result = validator.validate(dto);
+
+        assertTrue(result.isNotValid());
+        assertEquals(List.of("error.password.required"), result.getErrors());
+    }
+
+    @Test
+    void validate_shouldReturnError_whenPasswordIsTooShort() {
+        RegistrationDto dto = new RegistrationDto();
+        dto.setEmail("user@mail.ru");
+        dto.setPassword("123");
+
+        ValidationResult result = validator.validate(dto);
+
+        assertTrue(result.isNotValid());
+        assertEquals(List.of("error.password.short"), result.getErrors());
+    }
+
+    @Test
+    void validate_shouldReturnBothErrors_wherEmailAndPasswordAreInvalid() {
+        RegistrationDto dto = new RegistrationDto();
+        dto.setEmail("invalid");
+        dto.setPassword("123");
+
+        ValidationResult result = validator.validate(dto);
+
+        assertTrue(result.isNotValid());
+        assertEquals(
+                List.of("error.email.invalid", "error.password.short"),
+                result.getErrors()
+        );
+    }
+
+    @Test
+    void validate_shouldAcceptTrimmedEmailAndPassword() {
+        RegistrationDto dto = new RegistrationDto();
+        dto.setEmail("   user@mail.ru   ");
+        dto.setPassword("   123456   ");
+
+        ValidationResult result = validator.validate(dto);
+
+        assertFalse(result.isNotValid());
+    }
+}

--- a/back/src/test/java/ru/andrewb/charm/back/web/RequestParamUtilsTest.java
+++ b/back/src/test/java/ru/andrewb/charm/back/web/RequestParamUtilsTest.java
@@ -1,0 +1,108 @@
+package ru.andrewb.charm.back.web;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.Test;
+import ru.andrewb.charm.back.model.exception.BadRequestException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class RequestParamUtilsTest {
+
+    @Test
+    void requirePositiveLong_shouldReturnParsedValue_whenParameterIsValid() {
+        HttpServletRequest req = mock(HttpServletRequest.class);
+        when(req.getParameter("id")).thenReturn("42");
+
+        long result = RequestParamUtils.requirePositiveLong(req, "id");
+
+        assertEquals(42L, result);
+    }
+
+    @Test
+    void requirePositiveLong_shouldThrow_whenParameterIsMissing() {
+        HttpServletRequest req = mock(HttpServletRequest.class);
+        when(req.getParameter("id")).thenReturn(null);
+
+        BadRequestException ex = assertThrows(
+                BadRequestException.class,
+                () -> RequestParamUtils.requirePositiveLong(req, "id")
+        );
+
+        assertEquals("error.param.required", ex.getMessage());
+    }
+
+    @Test
+    void requirePositiveLong_shouldThrow_whenParameterIsBlank() {
+        HttpServletRequest req = mock(HttpServletRequest.class);
+        when(req.getParameter("id")).thenReturn("   ");
+
+        BadRequestException ex = assertThrows(
+                BadRequestException.class,
+                () -> RequestParamUtils.requirePositiveLong(req, "id")
+        );
+
+        assertEquals("error.param.required", ex.getMessage());
+    }
+
+    @Test
+    void requirePositiveLong_shouldThrow_whenParameterIsZero() {
+        HttpServletRequest req = mock(HttpServletRequest.class);
+        when(req.getParameter("id")).thenReturn("0");
+
+        BadRequestException ex = assertThrows(
+                BadRequestException.class,
+                () -> RequestParamUtils.requirePositiveLong(req, "id")
+        );
+
+        assertEquals("error.param.invalid", ex.getMessage());
+    }
+
+    @Test
+    void requirePositiveLong_shouldThrow_whenParameterIsNegative() {
+        HttpServletRequest req = mock(HttpServletRequest.class);
+        when(req.getParameter("id")).thenReturn("-5");
+
+        BadRequestException ex = assertThrows(
+                BadRequestException.class,
+                () -> RequestParamUtils.requirePositiveLong(req, "id")
+        );
+
+        assertEquals("error.param.invalid", ex.getMessage());
+    }
+
+    @Test
+    void requirePositiveLong_shouldThrow_whenParameterIsNotNumeric() {
+        HttpServletRequest req = mock(HttpServletRequest.class);
+        when(req.getParameter("id")).thenReturn("abc");
+
+        BadRequestException ex = assertThrows(
+                BadRequestException.class,
+                () -> RequestParamUtils.requirePositiveLong(req, "id")
+        );
+
+        assertEquals("error.param.invalid", ex.getMessage());
+    }
+
+    @Test
+    void rid_shouldReturnDash_whenAttributeIsMissing() {
+        HttpServletRequest req = mock(HttpServletRequest.class);
+        when(req.getAttribute("rid")).thenReturn(null);
+
+        String result = RequestParamUtils.rid(req);
+
+        assertEquals("-", result);
+    }
+
+    @Test
+    void rid_shouldReturnAttributeValue_whenAttributeExists() {
+        HttpServletRequest req = mock(HttpServletRequest.class);
+        when(req.getAttribute("rid")).thenReturn("req-123");
+
+        String result = RequestParamUtils.rid(req);
+
+        assertEquals("req-123", result);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -104,9 +104,21 @@
 
             <!-- Test -->
             <dependency>
-                <groupId>junit</groupId>
-                <artifactId>junit</artifactId>
-                <version>4.13.2</version>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter</artifactId>
+                <version>5.13.4</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-core</artifactId>
+                <version>5.18.0</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-junit-jupiter</artifactId>
+                <version>5.18.0</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>


### PR DESCRIPTION
## Changes

- added unit tests for:
  - validators
  - normalizers
  - security helpers
  - core mappers
  - `AuthUtils`
  - `ProfileService`
  - `CharmService`
  - `RequestParamUtils`
- added Mockito support for JUnit 5
- refactored `ProfileService` and `CharmService` to use constructor-injected dependencies
- refactored `ContentService` to remove static config-based initialization
- introduced `AppComponents` as a temporary composition root
- updated controllers and PDF mapping to use the new wiring approach

## Notes

- this is a transitional step toward Spring DI
- `AppComponents` is used as a temporary wiring layer before moving to Spring beans