### PR TITLE
Sanitize internal infrastructure exceptions

### DIFF
--- a/back/src/main/java/ru/andrewb/charm/back/controller/advice/MvcExceptionHandler.java
+++ b/back/src/main/java/ru/andrewb/charm/back/controller/advice/MvcExceptionHandler.java
@@ -12,7 +12,7 @@ import static ru.andrewb.charm.back.web.Views.*;
 public class MvcExceptionHandler {
 
     @ExceptionHandler(BadRequestException.class)
-    public String handleBadRequest(RuntimeException e, HttpServletResponse resp, Model model) {
+    public String handleBadRequest(BadRequestException e, HttpServletResponse resp, Model model) {
         resp.setStatus(HttpServletResponse.SC_BAD_REQUEST);
         model.addAttribute("errorCode", HttpServletResponse.SC_BAD_REQUEST);
         model.addAttribute("errorMessage", e.getMessage());
@@ -35,7 +35,23 @@ public class MvcExceptionHandler {
         return ERROR_409;
     }
 
-    @ExceptionHandler({Exception.class, StorageException.class})
+    @ExceptionHandler(InfrastructureException.class)
+    public String handleInfrastructure(InfrastructureException e, HttpServletResponse resp, Model model) {
+        resp.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+        model.addAttribute("errorCode", HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+        model.addAttribute("errorMessage", "error.internal");
+        return ERROR_500;
+    }
+
+    @ExceptionHandler(StorageException.class)
+    public String handleStorage(StorageException e, HttpServletResponse resp, Model model) {
+        resp.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+        model.addAttribute("errorCode", HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+        model.addAttribute("errorMessage", "error.internal");
+        return ERROR_500;
+    }
+
+    @ExceptionHandler(Exception.class)
     public String handleUnexpected(Exception e, HttpServletResponse resp, Model model) {
         resp.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
         model.addAttribute("errorCode", HttpServletResponse.SC_INTERNAL_SERVER_ERROR);

--- a/back/src/main/java/ru/andrewb/charm/back/controller/advice/RestExceptionHandler.java
+++ b/back/src/main/java/ru/andrewb/charm/back/controller/advice/RestExceptionHandler.java
@@ -52,7 +52,7 @@ public class RestExceptionHandler {
     }
 
     @ExceptionHandler({DuplicateEmailException.class, OptimisticLockException.class})
-    public ResponseEntity<ApiErrorResponse> handleConflict(Exception e) {
+    public ResponseEntity<ApiErrorResponse> handleConflict(RuntimeException e) {
         String code = e instanceof OptimisticLockException ? "error.optimistic-lock" : e.getMessage();
         return ResponseEntity.status(HttpStatus.CONFLICT)
                 .body(errorResponse(code));
@@ -62,6 +62,12 @@ public class RestExceptionHandler {
     public ResponseEntity<ApiErrorResponse> handleStorage(StorageException e) {
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body(errorResponse(e.getMessage()));
+    }
+
+    @ExceptionHandler(InfrastructureException.class)
+    public ResponseEntity<ApiErrorResponse> handleInfrastructure(InfrastructureException e) {
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(errorResponse("error.internal"));
     }
 
     @ExceptionHandler(Exception.class)

--- a/back/src/main/java/ru/andrewb/charm/back/dao/ProfileDao.java
+++ b/back/src/main/java/ru/andrewb/charm/back/dao/ProfileDao.java
@@ -6,6 +6,7 @@ import ru.andrewb.charm.back.dto.*;
 import ru.andrewb.charm.back.mapper.ResultSetToProfileMapper;
 import ru.andrewb.charm.back.mapper.ResultSetToProfileSimpleDtoMapper;
 import ru.andrewb.charm.back.model.Profile;
+import ru.andrewb.charm.back.model.exception.InfrastructureException;
 import ru.andrewb.charm.back.model.exception.OptimisticLockException;
 import ru.andrewb.charm.back.service.command.ProfileUpdateStatusCommand;
 
@@ -103,7 +104,7 @@ public class ProfileDao {
             }
             return profile;
         } catch (SQLException e) {
-            throw new RuntimeException(e);
+            throw new InfrastructureException("error.internal", e);
         }
     }
 
@@ -118,7 +119,7 @@ public class ProfileDao {
                 return Optional.empty();
             }
         } catch (SQLException e) {
-            throw new RuntimeException(e);
+            throw new InfrastructureException("error.internal", e);
         }
     }
 
@@ -133,7 +134,7 @@ public class ProfileDao {
                 return Optional.empty();
             }
         } catch (SQLException e) {
-            throw new RuntimeException(e);
+            throw new InfrastructureException("error.internal", e);
         }
     }
 
@@ -160,7 +161,7 @@ public class ProfileDao {
                 return profiles;
             }
         } catch (SQLException e) {
-            throw new RuntimeException(e);
+            throw new InfrastructureException("error.internal", e);
         }
     }
 
@@ -181,7 +182,7 @@ public class ProfileDao {
                 return profiles;
             }
         } catch (SQLException e) {
-            throw new RuntimeException(e);
+            throw new InfrastructureException("error.internal", e);
         }
     }
 
@@ -204,7 +205,7 @@ public class ProfileDao {
                 throw new OptimisticLockException("error.optimistic-lock");
             }
         } catch (SQLException e) {
-            throw new RuntimeException(e);
+            throw new InfrastructureException("error.internal", e);
         }
     }
 
@@ -239,7 +240,7 @@ public class ProfileDao {
             if (conn != null) {
                 try { conn.rollback(); } catch (SQLException ignored) {}
             }
-            throw new RuntimeException(e);
+            throw new InfrastructureException("error.internal", e);
         } finally {
             if (conn != null) {
                 try { conn.setAutoCommit(true); conn.close(); } catch (SQLException ignored) {}
@@ -254,7 +255,7 @@ public class ProfileDao {
             int deleted = ps.executeUpdate();
             return deleted > 0;
         } catch (SQLException e) {
-            throw new RuntimeException(e);
+            throw new InfrastructureException("error.internal", e);
         }
     }
 
@@ -271,7 +272,7 @@ public class ProfileDao {
                 return rs.next();
             }
         } catch (SQLException e) {
-            throw new RuntimeException(e);
+            throw new InfrastructureException("error.internal", e);
         }
     }
 
@@ -288,7 +289,7 @@ public class ProfileDao {
                 return profiles;
             }
         } catch (SQLException e) {
-            throw new RuntimeException(e);
+            throw new InfrastructureException("error.internal", e);
         }
     }
 

--- a/back/src/main/java/ru/andrewb/charm/back/dao/ProfileLikeDao.java
+++ b/back/src/main/java/ru/andrewb/charm/back/dao/ProfileLikeDao.java
@@ -2,6 +2,7 @@ package ru.andrewb.charm.back.dao;
 
 import org.springframework.stereotype.Repository;
 import ru.andrewb.charm.back.model.exception.BadRequestException;
+import ru.andrewb.charm.back.model.exception.InfrastructureException;
 
 import javax.sql.DataSource;
 import java.sql.Connection;
@@ -45,7 +46,7 @@ public class ProfileLikeDao {
             ps.setObject(4, likedB);
             ps.executeUpdate();
         } catch (SQLException e) {
-            throw new RuntimeException(e);
+            throw new InfrastructureException("error.internal", e);
         }
     }
 }

--- a/back/src/main/java/ru/andrewb/charm/back/model/exception/InfrastructureException.java
+++ b/back/src/main/java/ru/andrewb/charm/back/model/exception/InfrastructureException.java
@@ -1,0 +1,7 @@
+package ru.andrewb.charm.back.model.exception;
+
+public class InfrastructureException extends RuntimeException {
+    public InfrastructureException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/back/src/main/java/ru/andrewb/charm/back/service/ContentService.java
+++ b/back/src/main/java/ru/andrewb/charm/back/service/ContentService.java
@@ -4,6 +4,7 @@ import jakarta.servlet.ServletOutputStream;
 import org.springframework.stereotype.Service;
 import ru.andrewb.charm.back.config.AppContentProperties;
 import ru.andrewb.charm.back.model.exception.BadRequestException;
+import ru.andrewb.charm.back.model.exception.InfrastructureException;
 import ru.andrewb.charm.back.model.exception.NotFoundException;
 
 import java.io.IOException;
@@ -36,7 +37,7 @@ public class ContentService {
         } catch (IllegalArgumentException | SecurityException e) {
             throw new BadRequestException("error.content.invalid-path");
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            throw new InfrastructureException("error.internal", e);
         }
     }
 
@@ -57,7 +58,7 @@ public class ContentService {
         } catch (IllegalArgumentException | SecurityException e) {
             throw new BadRequestException("error.content.invalid-path");
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            throw new InfrastructureException("error.internal", e);
         }
     }
 
@@ -89,7 +90,7 @@ public class ContentService {
         try {
             Files.deleteIfExists(resolve(contentPath));
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            throw new InfrastructureException("error.internal", e);
         }
     }
 
@@ -97,7 +98,7 @@ public class ContentService {
         try {
             Files.deleteIfExists(resolve(segments));
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            throw new InfrastructureException("error.internal", e);
         }
     }
 
@@ -110,11 +111,11 @@ public class ContentService {
                         try {
                             Files.deleteIfExists(p);
                         } catch (IOException e) {
-                            throw new RuntimeException(e);
+                            throw new InfrastructureException("error.internal", e);
                         }
                     });
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            throw new InfrastructureException("error.internal", e);
         }
     }
 

--- a/back/src/main/java/ru/andrewb/charm/back/service/ProfileCacheService.java
+++ b/back/src/main/java/ru/andrewb/charm/back/service/ProfileCacheService.java
@@ -7,6 +7,7 @@ import redis.clients.jedis.JedisPool;
 import redis.clients.jedis.params.SetParams;
 import ru.andrewb.charm.back.config.AppRedisProperties;
 import ru.andrewb.charm.back.dto.ProfileSimpleDto;
+import ru.andrewb.charm.back.model.exception.InfrastructureException;
 
 import java.util.Queue;
 import java.util.UUID;
@@ -41,7 +42,7 @@ public class ProfileCacheService {
             String res = jedis.set(lockKey, token, SetParams.setParams().nx().ex(properties.getCharmLockTtlSec()));
             return "OK".equals(res) ? token : null;
         } catch (Exception e) {
-            throw new RuntimeException("redis tryAcquireLock failed", e);
+            throw new InfrastructureException("error.internal", e);
         }
     }
 
@@ -62,7 +63,7 @@ public class ProfileCacheService {
             Object res = jedis.eval(lua, 1, lockKey, token);
             return res.equals(1L);
         } catch (Exception e) {
-            throw new RuntimeException("redis releaseLock failed", e);
+            throw new InfrastructureException("error.internal", e);
         }
     }
 
@@ -75,7 +76,7 @@ public class ProfileCacheService {
             if (json == null) return null;
             return objectMapper.readValue(json, ProfileSimpleDto.class);
         } catch (Exception e) {
-            throw new RuntimeException("redis poll failed", e);
+            throw new InfrastructureException("error.internal", e);
         }
     }
 
@@ -94,7 +95,7 @@ public class ProfileCacheService {
             p.expire(key, properties.getCharmQueueTtlSec());
             p.sync();
         } catch (Exception e) {
-            throw new RuntimeException("redis replaceQueue failed", e);
+            throw new InfrastructureException("error.internal", e);
         }
     }
 


### PR DESCRIPTION
## Changes

- added `InfrastructureException` as a dedicated wrapper for internal technical failures
- replaced raw `RuntimeException` wrapping in:
  - `ProfileDao`
  - `ProfileLikeDao`
  - `ContentService`
  - `ProfileCacheService`
- added explicit handling for `InfrastructureException` in:
  - `RestExceptionHandler`
  - `MvcExceptionHandler`
- kept internal guard exceptions in `ContentService` as internal-only signals where they are immediately mapped to application error codes
