### PR TITLE
Pass JWT secret to Docker app container

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -73,6 +73,7 @@ services:
       APP_REDIS_HOST: ${APP_REDIS_HOST}
       APP_REDIS_PORT: ${APP_REDIS_PORT}
       APP_CONTENT_BASE_PATH: ${APP_CONTENT_BASE_PATH}
+      APP_JWT_SECRET: ${APP_JWT_SECRET}
     volumes:
       - charm-content:${APP_CONTENT_BASE_PATH}
     networks:


### PR DESCRIPTION
## Changes

- added `APP_JWT_SECRET` to the `app` service environment in `compose.yml`
- fixed Docker startup for JWT-enabled application profile
- verified that the application container starts successfully with the Docker profile after the change