### PR TITLE
Add OpenAPI documentation for REST API

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
 - HikariCP или `pool`-модуль
 - Jackson
 - iTextPDF
+- OpenAPI / Swagger UI
 - JUnit 5
 - Mockito
 - Testcontainers
@@ -313,6 +314,19 @@ curl http://localhost:8080/api/v1/profile `
 ```
 
 Без токена защищенные REST endpoints должны возвращать `401`.
+
+## Swagger / OpenAPI
+
+REST API документируется через `springdoc-openapi`.
+
+После запуска приложения доступны:
+
+- Swagger UI: `http://localhost:8080/swagger-ui.html`
+- OpenAPI JSON: `http://localhost:8080/v3/api-docs`
+- OpenAPI YAML: `http://localhost:8080/v3/api-docs.yaml`
+- Группа REST API: `http://localhost:8080/v3/api-docs/rest-api`
+
+В Swagger UI можно получить JWT через `POST /api/v1/auth/login`, нажать `Authorize` и вставить токен в формате `Bearer <token>`.
 
 ## Особенности реализации
 

--- a/back/pom.xml
+++ b/back/pom.xml
@@ -39,6 +39,11 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.8.17</version>
+        </dependency>
 
         <!--database-->
         <dependency>

--- a/back/src/main/java/ru/andrewb/charm/back/config/OpenApiConfig.java
+++ b/back/src/main/java/ru/andrewb/charm/back/config/OpenApiConfig.java
@@ -1,0 +1,37 @@
+package ru.andrewb.charm.back.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springdoc.core.models.GroupedOpenApi;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+    public static final String BEARER_AUTH = "bearerAuth";
+
+    @Bean
+    public OpenAPI charmOpenApi() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("Charm API")
+                        .description("REST API for the Charm mini-Tinder application")
+                        .version("1.0.0"))
+                .components(new Components()
+                        .addSecuritySchemes(BEARER_AUTH, new SecurityScheme()
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT")));
+    }
+
+    @Bean
+    public GroupedOpenApi restApi() {
+        return GroupedOpenApi.builder()
+                .group("rest-api")
+                .pathsToMatch("/api/v1/**")
+                .build();
+    }
+}

--- a/back/src/main/java/ru/andrewb/charm/back/config/SecurityConfig.java
+++ b/back/src/main/java/ru/andrewb/charm/back/config/SecurityConfig.java
@@ -80,7 +80,10 @@ public class SecurityConfig {
                                 "/js/**",
                                 "/assets/**",
                                 "/fonts/**",
-                                "/favicon.ico"
+                                "/favicon.ico",
+                                "/swagger-ui.html",
+                                "/swagger-ui/**",
+                                "/v3/api-docs/**"
                         ).permitAll()
                         .requestMatchers(ADMIN_URL + "/**").hasRole("ADMIN")
                         .anyRequest().authenticated()

--- a/back/src/main/java/ru/andrewb/charm/back/controller/request/CharmRequest.java
+++ b/back/src/main/java/ru/andrewb/charm/back/controller/request/CharmRequest.java
@@ -1,5 +1,6 @@
 package ru.andrewb.charm.back.controller.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
@@ -10,8 +11,12 @@ import ru.andrewb.charm.back.dto.Action;
 @Getter
 @Setter
 @ToString
+@Schema(description = "Charm action request")
 @FieldDefaults(level = AccessLevel.PRIVATE)
 public class CharmRequest {
+    @Schema(description = "Target profile id", example = "2")
     Long toProfileId;
+
+    @Schema(description = "Action for the target profile. SKIP does not persist a like/dislike.", example = "LIKE")
     Action action;
 }

--- a/back/src/main/java/ru/andrewb/charm/back/controller/request/EmailChangeRequest.java
+++ b/back/src/main/java/ru/andrewb/charm/back/controller/request/EmailChangeRequest.java
@@ -1,5 +1,6 @@
 package ru.andrewb.charm.back.controller.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -12,17 +13,21 @@ import lombok.experimental.FieldDefaults;
 @Getter
 @Setter
 @ToString(onlyExplicitlyIncluded = true)
+@Schema(description = "Email change request")
 @FieldDefaults(level = AccessLevel.PRIVATE)
 public class EmailChangeRequest {
 
     @ToString.Include
+    @Schema(description = "New email", example = "new-email@mail.com")
     @NotBlank(message = "error.email.required")
     @Email(message = "error.email.invalid")
     String newEmail;
 
+    @Schema(description = "Current password", example = "123456", accessMode = Schema.AccessMode.WRITE_ONLY)
     @NotBlank(message = "error.password.current-required")
     String currentPassword;
 
+    @Schema(description = "Optimistic locking version", example = "0")
     @NotNull(message = "error.param.required")
     Integer version;
 }

--- a/back/src/main/java/ru/andrewb/charm/back/controller/request/JwtLoginRequest.java
+++ b/back/src/main/java/ru/andrewb/charm/back/controller/request/JwtLoginRequest.java
@@ -1,5 +1,6 @@
 package ru.andrewb.charm.back.controller.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -8,12 +9,15 @@ import lombok.experimental.FieldDefaults;
 
 @Getter
 @Setter
+@Schema(description = "Login request")
 @FieldDefaults(level = AccessLevel.PRIVATE)
 public class JwtLoginRequest {
 
+    @Schema(description = "User email", example = "ivanov@mail.ru")
     @NotBlank(message = "error.email.required")
     String email;
 
+    @Schema(description = "User password", example = "123456", accessMode = Schema.AccessMode.WRITE_ONLY)
     @NotBlank(message = "error.password.required")
     String password;
 }

--- a/back/src/main/java/ru/andrewb/charm/back/controller/request/PasswordChangeRequest.java
+++ b/back/src/main/java/ru/andrewb/charm/back/controller/request/PasswordChangeRequest.java
@@ -1,5 +1,6 @@
 package ru.andrewb.charm.back.controller.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -10,19 +11,24 @@ import lombok.experimental.FieldDefaults;
 
 @Getter
 @Setter
+@Schema(description = "Password change request")
 @FieldDefaults(level = AccessLevel.PRIVATE)
 public class PasswordChangeRequest {
 
+    @Schema(description = "Current password", example = "123456", accessMode = Schema.AccessMode.WRITE_ONLY)
     @NotBlank(message = "error.password.current-required")
     String currentPassword;
 
+    @Schema(description = "New password, at least 6 characters", example = "654321", accessMode = Schema.AccessMode.WRITE_ONLY)
     @NotBlank(message = "error.password.new-required")
     @Size(min = 6, message = "error.password.short")
     String newPassword;
 
+    @Schema(description = "New password confirmation", example = "654321", accessMode = Schema.AccessMode.WRITE_ONLY)
     @NotBlank(message = "error.password.confirm-required")
     String confirmPassword;
 
+    @Schema(description = "Optimistic locking version", example = "0")
     @NotNull(message = "error.param.required")
     Integer version;
 }

--- a/back/src/main/java/ru/andrewb/charm/back/controller/request/ProfileUpdateRequest.java
+++ b/back/src/main/java/ru/andrewb/charm/back/controller/request/ProfileUpdateRequest.java
@@ -1,5 +1,6 @@
 package ru.andrewb.charm.back.controller.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Past;
 import jakarta.validation.constraints.Size;
@@ -14,25 +15,33 @@ import java.time.LocalDate;
 
 @Getter
 @Setter
+@Schema(description = "Profile update request")
 @FieldDefaults(level = AccessLevel.PRIVATE)
 public class ProfileUpdateRequest {
 
+    @Schema(description = "Name", example = "Ivan")
     @Size(max = 100, message = "error.name.too-long")
     String name;
 
+    @Schema(description = "Surname", example = "Ivanov")
     @Size(max = 100, message = "error.surname.too-long")
     String surname;
 
+    @Schema(description = "Profile description", example = "I am a Java Dev")
     @Size(max = 1000, message = "error.about.too-long")
     String about;
 
+    @Schema(description = "Birth date", example = "2001-12-03")
     @Past(message = "error.birthdate.future")
     LocalDate birthdate;
 
+    @Schema(description = "Gender", example = "MALE")
     Gender gender;
 
+    @Schema(description = "Optimistic locking version", example = "0")
     @NotNull(message = "error.param.required")
     Integer version;
 
+    @Schema(hidden = true)
     MultipartFile photo;
 }

--- a/back/src/main/java/ru/andrewb/charm/back/controller/request/ProfilesFilterRequest.java
+++ b/back/src/main/java/ru/andrewb/charm/back/controller/request/ProfilesFilterRequest.java
@@ -1,5 +1,6 @@
 package ru.andrewb.charm.back.controller.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Min;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -12,27 +13,44 @@ import ru.andrewb.charm.back.model.Status;
 
 @Getter
 @Setter
+@Schema(description = "Admin profile search filters")
 @FieldDefaults(level = AccessLevel.PRIVATE)
 public class ProfilesFilterRequest {
 
+    @Schema(description = "Email prefix", example = "ivan")
     String emailStartsWith;
+
+    @Schema(description = "Name prefix", example = "Iv")
     String nameStartsWith;
+
+    @Schema(description = "Surname prefix", example = "Iv")
     String surnameStartsWith;
 
+    @Schema(description = "Upper age bound, exclusive", example = "35")
     @Min(value = 0, message = "error.param.invalid")
     Integer ltAge;
 
+    @Schema(description = "Lower age bound, inclusive", example = "18")
     @Min(value = 0, message = "error.param.invalid")
     Integer gteAge;
 
+    @Schema(description = "Profile role", example = "USER")
     Role role;
+
+    @Schema(description = "Profile status", example = "ACTIVE")
     Status status;
+
+    @Schema(description = "Sort field", example = "ID")
     SortBy sortBy;
+
+    @Schema(description = "Sort order", example = "ASC")
     SortOrder sortOrder;
 
+    @Schema(description = "Page number, starting from 1", example = "1")
     @Min(value = 1, message = "error.param.invalid")
     Integer page;
 
+    @Schema(description = "Items per page", example = "20")
     @Min(value = 1, message = "error.param.invalid")
     Integer pageSize;
 }

--- a/back/src/main/java/ru/andrewb/charm/back/controller/request/RegistrationRequest.java
+++ b/back/src/main/java/ru/andrewb/charm/back/controller/request/RegistrationRequest.java
@@ -1,5 +1,6 @@
 package ru.andrewb.charm.back.controller.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
@@ -12,14 +13,17 @@ import lombok.experimental.FieldDefaults;
 @Getter
 @Setter
 @ToString(onlyExplicitlyIncluded = true)
+@Schema(description = "Registration request")
 @FieldDefaults(level = AccessLevel.PRIVATE)
 public class RegistrationRequest {
 
     @ToString.Include
+    @Schema(description = "User email", example = "new-user@mail.com")
     @NotBlank(message = "error.email.required")
     @Email(message = "error.email.invalid")
     String email;
 
+    @Schema(description = "User password, at least 6 characters", example = "123456", accessMode = Schema.AccessMode.WRITE_ONLY)
     @NotBlank(message = "error.password.required")
     @Size(min = 6, message = "error.password.short")
     String password;

--- a/back/src/main/java/ru/andrewb/charm/back/controller/rest/AdminProfileRestController.java
+++ b/back/src/main/java/ru/andrewb/charm/back/controller/rest/AdminProfileRestController.java
@@ -1,5 +1,9 @@
 package ru.andrewb.charm.back.controller.rest;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -8,8 +12,11 @@ import ru.andrewb.charm.back.controller.request.ProfileUpdateRequest;
 import ru.andrewb.charm.back.mapper.ProfileUpdateRequestToCommandMapper;
 import ru.andrewb.charm.back.service.ProfileService;
 
+import static ru.andrewb.charm.back.config.OpenApiConfig.BEARER_AUTH;
 import static ru.andrewb.charm.back.web.Urls.ADMIN_PROFILES_REST_URL;
 
+@Tag(name = "Admin profile", description = "Admin single profile operations")
+@SecurityRequirement(name = BEARER_AUTH)
 @RestController
 @RequestMapping(ADMIN_PROFILES_REST_URL)
 @PreAuthorize("hasRole('ADMIN')")
@@ -26,22 +33,25 @@ public class AdminProfileRestController {
         this.mapper = mapper;
     }
 
+    @Operation(summary = "Get profile by id as admin")
     @GetMapping("/{id}")
-    public ResponseEntity<?> getProfile(@PathVariable("id") Long id) {
+    public ResponseEntity<?> getProfile(@Parameter(example = "1") @PathVariable("id") Long id) {
         return ResponseEntity.ok(service.findByIdOrThrow(id));
     }
 
+    @Operation(summary = "Update profile by id as admin")
     @PutMapping("/{id}")
     public ResponseEntity<?> updateProfile(
-            @PathVariable("id") Long id,
+            @Parameter(example = "1") @PathVariable("id") Long id,
             @Valid @RequestBody ProfileUpdateRequest request
     ) {
         service.update(id, mapper.map(request), null);
         return ResponseEntity.noContent().build();
     }
 
+    @Operation(summary = "Delete profile by id as admin")
     @DeleteMapping("/{id}")
-    public ResponseEntity<?> deleteProfile(@PathVariable("id") Long id) {
+    public ResponseEntity<?> deleteProfile(@Parameter(example = "1") @PathVariable("id") Long id) {
         service.delete(id);
         return ResponseEntity.noContent().build();
     }

--- a/back/src/main/java/ru/andrewb/charm/back/controller/rest/AdminProfilesRestController.java
+++ b/back/src/main/java/ru/andrewb/charm/back/controller/rest/AdminProfilesRestController.java
@@ -1,5 +1,8 @@
 package ru.andrewb.charm.back.controller.rest;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -12,8 +15,11 @@ import ru.andrewb.charm.back.dto.ProfilesFilter;
 import ru.andrewb.charm.back.mapper.ProfilesFilterRequestToProfileFilterMapper;
 import ru.andrewb.charm.back.service.ProfileService;
 
+import static ru.andrewb.charm.back.config.OpenApiConfig.BEARER_AUTH;
 import static ru.andrewb.charm.back.web.Urls.ADMIN_PROFILES_REST_URL;
 
+@Tag(name = "Admin profiles", description = "Admin profile search")
+@SecurityRequirement(name = BEARER_AUTH)
 @RestController
 @RequestMapping(ADMIN_PROFILES_REST_URL)
 @PreAuthorize("hasRole('ADMIN')")
@@ -30,6 +36,7 @@ public class AdminProfilesRestController {
         this.mapper = mapper;
     }
 
+    @Operation(summary = "Search profiles as admin")
     @GetMapping
     public ResponseEntity<?> getProfiles(@Valid @ModelAttribute ProfilesFilterRequest request) {
         ProfilesFilter filter = mapper.map(request);

--- a/back/src/main/java/ru/andrewb/charm/back/controller/rest/AuthRestController.java
+++ b/back/src/main/java/ru/andrewb/charm/back/controller/rest/AuthRestController.java
@@ -1,5 +1,9 @@
 package ru.andrewb.charm.back.controller.rest;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -20,6 +24,7 @@ import static ru.andrewb.charm.back.web.Urls.AUTH_REST_URL;
 import static ru.andrewb.charm.back.web.Urls.LOGIN_URL;
 
 @Slf4j
+@Tag(name = "Auth", description = "JWT authentication")
 @RestController
 @RequestMapping(AUTH_REST_URL)
 public class AuthRestController {
@@ -35,6 +40,12 @@ public class AuthRestController {
         this.jwtService = jwtService;
     }
 
+    @Operation(summary = "Login", description = "Authenticates a user and returns a JWT access token.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Login successful"),
+            @ApiResponse(responseCode = "400", description = "Invalid request body"),
+            @ApiResponse(responseCode = "401", description = "Invalid credentials")
+    })
     @PostMapping(LOGIN_URL)
     public ResponseEntity<JwtTokenResponse> login(@Valid @RequestBody JwtLoginRequest request) {
         log.info("REST login attempt email={}", request.getEmail());

--- a/back/src/main/java/ru/andrewb/charm/back/controller/rest/CharmRestController.java
+++ b/back/src/main/java/ru/andrewb/charm/back/controller/rest/CharmRestController.java
@@ -1,5 +1,10 @@
 package ru.andrewb.charm.back.controller.rest;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -12,8 +17,11 @@ import ru.andrewb.charm.back.security.AuthUser;
 import ru.andrewb.charm.back.service.CharmService;
 import ru.andrewb.charm.back.service.command.CharmCommand;
 
+import static ru.andrewb.charm.back.config.OpenApiConfig.BEARER_AUTH;
 import static ru.andrewb.charm.back.web.Urls.CHARM_REST_URL;
 
+@Tag(name = "Charm", description = "Recommendations, likes, dislikes, and skips")
+@SecurityRequirement(name = BEARER_AUTH)
 @RestController
 @RequestMapping(CHARM_REST_URL)
 public class CharmRestController {
@@ -29,10 +37,12 @@ public class CharmRestController {
         this.mapper = mapper;
     }
 
+    @Schema(description = "Next recommendation response. The profile is null when there are no candidates.")
     public record NextResponse(ProfileSimpleDto profile) {}
 
+    @Operation(summary = "Get next recommendation")
     @GetMapping
-    public ResponseEntity<?> getNext(@AuthenticationPrincipal AuthUser user) {
+    public ResponseEntity<?> getNext(@Parameter(hidden = true) @AuthenticationPrincipal AuthUser user) {
         var command = new CharmCommand();
         command.setFromProfileId(user.getId());
         CharmCommandDefaults.normalize(command);
@@ -41,9 +51,10 @@ public class CharmRestController {
         return ResponseEntity.ok(new NextResponse(nextOpt.orElse(null)));
     }
 
+    @Operation(summary = "Save charm action and get next recommendation")
     @PostMapping
     public ResponseEntity<?> postAction(
-            @AuthenticationPrincipal AuthUser user,
+            @Parameter(hidden = true) @AuthenticationPrincipal AuthUser user,
             @Valid @RequestBody CharmRequest request
     ) {
         CharmCommand command = mapper.map(request);

--- a/back/src/main/java/ru/andrewb/charm/back/controller/rest/MatchesRestController.java
+++ b/back/src/main/java/ru/andrewb/charm/back/controller/rest/MatchesRestController.java
@@ -1,5 +1,10 @@
 package ru.andrewb.charm.back.controller.rest;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -12,8 +17,11 @@ import ru.andrewb.charm.back.service.ProfileService;
 
 import java.util.List;
 
+import static ru.andrewb.charm.back.config.OpenApiConfig.BEARER_AUTH;
 import static ru.andrewb.charm.back.web.Urls.MATCHES_REST_URL;
 
+@Tag(name = "Matches", description = "Mutual likes")
+@SecurityRequirement(name = BEARER_AUTH)
 @RestController
 @RequestMapping(MATCHES_REST_URL)
 public class MatchesRestController {
@@ -24,12 +32,16 @@ public class MatchesRestController {
         this.service = service;
     }
 
+    @Schema(description = "Paged matches response")
     public record MatchesResponse(List<ProfileGetDto> items, boolean hasNext) {}
 
+    @Operation(summary = "Get current user matches")
     @GetMapping
     public ResponseEntity<?> getMatches(
-            @AuthenticationPrincipal AuthUser user,
+            @Parameter(hidden = true) @AuthenticationPrincipal AuthUser user,
+            @Parameter(description = "Page number, starting from 1", example = "1")
             @RequestParam(name = "page", required = false) Integer page,
+            @Parameter(description = "Items per page", example = "10")
             @RequestParam(name = "pageSize", required = false) Integer pageSize
     ) {
         int normalizedPage = (page == null || page < 1) ? 1 : page;

--- a/back/src/main/java/ru/andrewb/charm/back/controller/rest/ProfileRestController.java
+++ b/back/src/main/java/ru/andrewb/charm/back/controller/rest/ProfileRestController.java
@@ -1,5 +1,9 @@
 package ru.andrewb.charm.back.controller.rest;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
@@ -19,8 +23,11 @@ import ru.andrewb.charm.back.service.command.EmailChangeCommand;
 import ru.andrewb.charm.back.service.command.PasswordChangeCommand;
 import ru.andrewb.charm.back.service.command.ProfileUpdateCommand;
 
+import static ru.andrewb.charm.back.config.OpenApiConfig.BEARER_AUTH;
 import static ru.andrewb.charm.back.web.Urls.PROFILE_REST_URL;
 
+@Tag(name = "Profile", description = "Current user profile")
+@SecurityRequirement(name = BEARER_AUTH)
 @RestController
 @RequestMapping(PROFILE_REST_URL)
 public class ProfileRestController {
@@ -42,14 +49,16 @@ public class ProfileRestController {
         this.passwordChangeRequestToCommandMapper = passwordChangeRequestToCommandMapper;
     }
 
+    @Operation(summary = "Get current profile")
     @GetMapping
-    public ResponseEntity<?> getProfile(@AuthenticationPrincipal AuthUser user) {
+    public ResponseEntity<?> getProfile(@Parameter(hidden = true) @AuthenticationPrincipal AuthUser user) {
         return ResponseEntity.ok(service.findByIdOrThrow(user.getId()));
     }
 
+    @Operation(summary = "Update current profile")
     @PutMapping
     public ResponseEntity<?> updateProfile(
-            @AuthenticationPrincipal AuthUser user,
+            @Parameter(hidden = true) @AuthenticationPrincipal AuthUser user,
             @Valid @RequestBody ProfileUpdateRequest request
     ) {
         ProfileUpdateCommand command = profileUpdateRequestToCommandMapper.map(request);
@@ -57,9 +66,10 @@ public class ProfileRestController {
         return ResponseEntity.noContent().build();
     }
 
+    @Operation(summary = "Change current user email")
     @PutMapping("/email")
     public ResponseEntity<?> changeEmail(
-            @AuthenticationPrincipal AuthUser user,
+            @Parameter(hidden = true) @AuthenticationPrincipal AuthUser user,
             @Valid @RequestBody EmailChangeRequest request
     ) {
         EmailChangeCommand command = emailChangeRequestToCommandMapper.map(request);
@@ -67,9 +77,10 @@ public class ProfileRestController {
         return ResponseEntity.noContent().build();
     }
 
+    @Operation(summary = "Change current user password")
     @PutMapping("/password")
     public ResponseEntity<?> changePassword(
-            @AuthenticationPrincipal AuthUser user,
+            @Parameter(hidden = true) @AuthenticationPrincipal AuthUser user,
             @Valid @RequestBody PasswordChangeRequest request
     ) {
         PasswordChangeCommand command = passwordChangeRequestToCommandMapper.map(request);
@@ -77,11 +88,12 @@ public class ProfileRestController {
         return ResponseEntity.noContent().build();
     }
 
+    @Operation(summary = "Delete current profile")
     @DeleteMapping
     public ResponseEntity<?> deleteProfile(
-            @AuthenticationPrincipal AuthUser user,
-            HttpServletRequest req,
-            HttpServletResponse resp
+            @Parameter(hidden = true) @AuthenticationPrincipal AuthUser user,
+            @Parameter(hidden = true) HttpServletRequest req,
+            @Parameter(hidden = true) HttpServletResponse resp
     ) {
         service.delete(user.getId());
         new SecurityContextLogoutHandler().logout(req, resp, null);

--- a/back/src/main/java/ru/andrewb/charm/back/controller/rest/RegistrationRestController.java
+++ b/back/src/main/java/ru/andrewb/charm/back/controller/rest/RegistrationRestController.java
@@ -1,5 +1,9 @@
 package ru.andrewb.charm.back.controller.rest;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -15,6 +19,7 @@ import java.util.Map;
 
 import static ru.andrewb.charm.back.web.Urls.REGISTRATION_REST_URL;
 
+@Tag(name = "Registration", description = "User registration")
 @RestController
 @RequestMapping(REGISTRATION_REST_URL)
 public class RegistrationRestController {
@@ -30,6 +35,12 @@ public class RegistrationRestController {
         this.mapper = mapper;
     }
 
+    @Operation(summary = "Register user", description = "Creates a new inactive user profile.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "User registered"),
+            @ApiResponse(responseCode = "400", description = "Validation failed"),
+            @ApiResponse(responseCode = "409", description = "Email is already registered")
+    })
     @PostMapping
     public ResponseEntity<?> register(@Valid @RequestBody RegistrationRequest request) {
         Long id = service.save(mapper.map(request));

--- a/back/src/main/java/ru/andrewb/charm/back/dto/ApiError.java
+++ b/back/src/main/java/ru/andrewb/charm/back/dto/ApiError.java
@@ -1,7 +1,12 @@
 package ru.andrewb.charm.back.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "API error item")
 public record ApiError(
+        @Schema(description = "Stable error code", example = "error.param.invalid")
         String code,
+        @Schema(description = "Localized error message", example = "Invalid parameter")
         String message
 ) {
 }

--- a/back/src/main/java/ru/andrewb/charm/back/dto/ApiErrorResponse.java
+++ b/back/src/main/java/ru/andrewb/charm/back/dto/ApiErrorResponse.java
@@ -1,8 +1,12 @@
 package ru.andrewb.charm.back.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.List;
 
+@Schema(description = "API error response")
 public record ApiErrorResponse(
+        @Schema(description = "List of errors")
         List<ApiError> errors
 ) {
 }

--- a/back/src/main/java/ru/andrewb/charm/back/dto/JwtTokenResponse.java
+++ b/back/src/main/java/ru/andrewb/charm/back/dto/JwtTokenResponse.java
@@ -1,16 +1,23 @@
 package ru.andrewb.charm.back.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.FieldDefaults;
 
 @Getter
+@Schema(description = "JWT token response")
 @FieldDefaults(level = AccessLevel.PRIVATE)
 @RequiredArgsConstructor(access = AccessLevel.PUBLIC)
 public class JwtTokenResponse {
 
+    @Schema(description = "JWT access token")
     final String accessToken;
+
+    @Schema(description = "Token type", example = "Bearer")
     final String tokenType;
+
+    @Schema(description = "Token lifetime in seconds", example = "3600")
     final long expiresIn;
 }

--- a/back/src/main/java/ru/andrewb/charm/back/dto/ProfileGetDto.java
+++ b/back/src/main/java/ru/andrewb/charm/back/dto/ProfileGetDto.java
@@ -1,5 +1,6 @@
 package ru.andrewb.charm.back.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
@@ -14,24 +15,47 @@ import java.time.LocalDate;
 @Getter
 @Setter
 @ToString(onlyExplicitlyIncluded = true)
+@Schema(description = "Full profile DTO")
 @FieldDefaults(level = AccessLevel.PRIVATE)
 public class ProfileGetDto {
     @ToString.Include
+    @Schema(description = "Profile id", example = "1")
     Long id;
+
     @ToString.Include
+    @Schema(description = "Profile email", example = "ivanov@mail.ru")
     String email;
+
     @ToString.Include
+    @Schema(description = "Name", example = "Ivan")
     String name;
+
     @ToString.Include
+    @Schema(description = "Surname", example = "Ivanov")
     String surname;
+
     @ToString.Include
+    @Schema(description = "Calculated age", example = "24")
     Integer age;
 
+    @Schema(description = "Profile description", example = "I am QA")
     String about;
+
+    @Schema(description = "Birthdate", example = "2001-12-03")
     LocalDate birthdate;
+
+    @Schema(description = "Gender", example = "MALE")
     Gender gender;
+
+    @Schema(description = "Profile status", example = "ACTIVE")
     Status status;
+
+    @Schema(description = "Stored profile photo filename", example = "avatar.jpg")
     String photo;
+
+    @Schema(description = "Profile role", example = "USER")
     Role role;
+
+    @Schema(description = "Optimistic locking version", example = "0")
     Integer version;
 }

--- a/back/src/main/java/ru/andrewb/charm/back/dto/ProfileSimpleDto.java
+++ b/back/src/main/java/ru/andrewb/charm/back/dto/ProfileSimpleDto.java
@@ -1,5 +1,6 @@
 package ru.andrewb.charm.back.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
@@ -9,17 +10,28 @@ import lombok.experimental.FieldDefaults;
 @Getter
 @Setter
 @ToString(onlyExplicitlyIncluded = true)
+@Schema(description = "Short profile DTO used in recommendations")
 @FieldDefaults(level = AccessLevel.PRIVATE)
 public class ProfileSimpleDto {
     @ToString.Include
+    @Schema(description = "Profile id", example = "2")
     Long id;
+
     @ToString.Include
+    @Schema(description = "Name", example = "Elena")
     String name;
+
     @ToString.Include
+    @Schema(description = "Surname", example = "Sidorova")
     String surname;
+
     @ToString.Include
+    @Schema(description = "Calculated age", example = "26")
     Integer age;
 
+    @Schema(description = "Profile description", example = "I am Java Dev")
     String about;
+
+    @Schema(description = "Stored profile photo filename", example = "avatar.jpg")
     String photo;
 }


### PR DESCRIPTION
## Changes

- add springdoc-openapi Swagger UI support
- configure OpenAPI metadata, REST API grouping, and JWT Bearer authentication scheme
- expose Swagger UI and OpenAPI docs through Spring Security
- add OpenAPI annotations to REST controllers and request/response DTOs
- document Swagger UI and OpenAPI endpoints in README
