### PR TITLE
Add GitHub Actions CI and Docker publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         run: chmod +x ./mvnw
 
       - name: Run unit tests
-        run: ./mvnw -pl back test
+        run: ./mvnw -pl back -am test
 
       - name: Run full verification
-        run: ./mvnw -pl back verify
+        run: ./mvnw -pl back -am verify

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  test:
+    name: Test and verify
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+
+      - name: Make Maven wrapper executable
+        run: chmod +x ./mvnw
+
+      - name: Run unit tests
+        run: ./mvnw -pl back test
+
+      - name: Run full verification
+        run: ./mvnw -pl back verify

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -25,7 +25,7 @@ jobs:
         run: chmod +x ./mvnw
 
       - name: Verify project
-        run: ./mvnw -pl back verify
+        run: ./mvnw -pl back -am verify
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v4

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,55 @@
+name: Docker Publish
+
+on:
+  push:
+    branches: ["main"]
+    tags: ['v*.*.*']
+
+jobs:
+  docker:
+    name: Build and push Docker image
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+
+      - name: Make Maven executable
+        run: chmod +x ./mvnw
+
+      - name: Verify project
+        run: ./mvnw -pl back verify
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: andrewbcodes/charm-back
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=dev,enable={{is_default_branch}}
+            type=semver,pattern={{version}}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@
 - Mockito
 - Testcontainers
 - Docker / Docker Compose
+- GitHub Actions
 
 ## Что умеет приложение
 
@@ -52,23 +53,45 @@
 |-- pom.xml
 |-- Dockerfile
 |-- compose.yml
+|-- compose.dockerhub.yml
+|-- .dockerignore
 |-- .env.example
+|-- .github/
+|   `-- workflows/
+|       |-- ci.yml
+|       `-- docker-publish.yml
 |-- back/
 |   |-- pom.xml
-|   |-- src/main/java
-|   |-- src/main/resources
+|   |-- src/main/java/ru/andrewb/charm/back
+|   |   |-- config
+|   |   |-- controller
+|   |   |-- dao
+|   |   |-- dto
+|   |   |-- mapper
+|   |   |-- model
+|   |   |-- normalizer
+|   |   |-- security
+|   |   |-- service
+|   |   |-- validator
+|   |   `-- web
+|   |-- src/main/resources/
 |   |   |-- application.yml
 |   |   |-- application-docker.yml
 |   |   |-- application-local.example.yml
-|   |   `-- db/migration
-|   |-- src/main/webapp
-|   `-- src/test/java
+|   |   |-- db/migration
+|   |   |-- db/sql
+|   |   `-- words*.properties
+|   |-- src/main/webapp/
+|   |   |-- WEB-INF/jsp
+|   |   |-- img
+|   |   `-- favicon.ico
+|   `-- src/test/java/ru/andrewb/charm/back
 |-- pool/
 |   |-- pom.xml
-|   `-- src/main/java
+|   `-- src/main/java/ru/andrewb/charm/pool
 `-- linecount-maven-plugin/
     |-- pom.xml
-    `-- src/main/java
+    `-- src/main/java/ru/andrewb/charm/plugin/linecount
 ```
 
 ## Конфигурация
@@ -251,15 +274,54 @@ Unit-тесты:
 
 Схема запуска тестов:
 
-- `mvn test` - только unit-тесты через `surefire`
-- `mvn verify` - unit + integration-тесты через `failsafe`
+- `./mvnw test` - только unit-тесты через `surefire`
+- `./mvnw verify` - unit + integration-тесты через `failsafe`
 
 Integration-тесты используют Testcontainers:
 
 - `PostgreSQLContainer`
 - `GenericContainer` для Redis
 
-Для `mvn verify` нужен доступный Docker. Если Docker недоступен, используйте `mvn test` для запуска unit-тестов.
+## CI/CD
+
+В проекте настроены GitHub Actions workflows:
+
+- `CI` - запускается на pull request и push в `main`
+- `Docker Publish` - запускается на push в `main` и на git tags вида `v*.*.*`
+
+`CI` проверяет проект автоматически:
+
+```powershell
+./mvnw -pl back test
+./mvnw -pl back verify
+```
+
+`test` запускает unit-тесты через Surefire. `verify` запускает unit- и integration-тесты через Surefire/Failsafe.
+
+`Docker Publish` собирает Docker image и публикует его в Docker Hub:
+
+- при push в `main` публикуются теги `latest` и `dev`
+- при push git tag вида `v0.4.0` публикуется Docker tag `0.4.0`
+
+Docker image:
+
+```text
+andrewbcodes/charm-back
+```
+
+Для публикации используются GitHub Actions secrets:
+
+```text
+DOCKERHUB_USERNAME
+DOCKERHUB_TOKEN
+```
+
+Чтобы выпустить новую версию Docker image:
+
+```powershell
+git tag v0.4.0
+git push origin v0.4.0
+```
 
 ## Основные маршруты
 


### PR DESCRIPTION
## Changes

- add CI workflow for pull requests and pushes to main
- add Docker image publishing workflow for main and version tags
- document GitHub Actions and Docker Hub publishing flow in README

## Workflows

- `CI` runs Maven tests and verification
- `Docker Publish` builds and pushes `andrewbcodes/charm-back` to Docker Hub
