### PR TITLE
Add Prometheus and Grafana observability

### DIFF
--- a/.env.prod.example
+++ b/.env.prod.example
@@ -18,3 +18,6 @@ APP_REDIS_PORT=6379
 APP_CONTENT_BASE_PATH=/app/content
 
 APP_JWT_SECRET=change-me-change-me-change-me-change-me
+
+GRAFANA_ADMIN_USER=admin
+GRAFANA_ADMIN_PASSWORD=change-me

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -72,3 +72,8 @@ jobs:
             docker compose pull app
             docker compose up -d
             docker image prune -f
+            for i in 1 2 3 4 5; do
+              curl -fsS https://charm-app.ru/ > /dev/null && exit 0
+              sleep 5
+            done
+            exit 1

--- a/back/pom.xml
+++ b/back/pom.xml
@@ -45,6 +45,16 @@
             <version>2.8.17</version>
         </dependency>
 
+        <!--observability-->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+        </dependency>
+
         <!--database-->
         <dependency>
             <groupId>org.postgresql</groupId>

--- a/back/src/main/resources/application.yml
+++ b/back/src/main/resources/application.yml
@@ -37,6 +37,19 @@ springdoc:
   swagger-ui:
     enabled: true
 
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,prometheus
+  endpoint:
+    health:
+      probes:
+        enabled: true
+  metrics:
+    tags:
+      application: charm-back
+
 server:
   forward-headers-strategy: framework
   servlet:

--- a/compose.prod.yml
+++ b/compose.prod.yml
@@ -59,10 +59,36 @@ services:
     networks:
       - charm-net
 
+  prometheus:
+    image: prom/prometheus:v3.7.3
+    container_name: charm-prometheus
+    restart: unless-stopped
+    volumes:
+      - ./monitoring/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - charm-prometheus-data:/prometheus
+    networks:
+      - charm-net
+
+  grafana:
+    image: grafana/grafana:12.3.0
+    container_name: charm-grafana
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:3000:3000"
+    environment:
+      GF_SECURITY_ADMIN_USER: ${GRAFANA_ADMIN_USER}
+      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD}
+    volumes:
+      - charm-grafana-data:/var/lib/grafana
+    networks:
+      - charm-net
+
 volumes:
   charm-postgres-data:
   charm-redis-data:
   charm-content:
+  charm-prometheus-data:
+  charm-grafana-data:
 
 networks:
   charm-net:

--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -1,0 +1,9 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: charm-back
+    metrics_path: /actuator/prometheus
+    static_configs:
+      - targets:
+          - app:8080


### PR DESCRIPTION
## Changes

- add Spring Boot Actuator and Prometheus registry
- expose health, info, and Prometheus actuator endpoints
- add Prometheus configuration for scraping the app
- add Prometheus and Grafana services to production Compose
- add Grafana production credentials to env example
- add deploy healthcheck after VPS update
